### PR TITLE
docs(backlog): NT-044 Facebook — code serveur présent mais à valider

### DIFF
--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -29,8 +29,8 @@ et ses vues dérivées. Il pilote le développement, y compris depuis Claude Cod
 3. **Sens de mise à jour** : on modifie **toujours** le backlog unifié d'abord,
    puis on répercute dans la ou les vues concernées. Jamais l'inverse.
 4. **Cohérence des statuts** : un même ID a le **même statut global** partout ; une
-   vue peut préciser un statut *par côté* en note (ex. NT-044 : serveur FAIT / app
-   À FAIRE) mais ne le contredit pas.
+   vue peut préciser un statut *par côté* en note (ex. NT-048 : serveur FAIT /
+   adoption app à câbler) mais ne le contredit pas.
 5. **IDs stables, jamais réutilisés.** Un item abandonné passe en `Won't-now` ou est
    marqué obsolète — son ID n'est pas recyclé. Les trous de numérotation par thème
    sont volontaires (réservés à l'insertion).

--- a/docs/backlog/backlog-unifie.md
+++ b/docs/backlog/backlog-unifie.md
@@ -268,7 +268,7 @@
 | NT-041 | Authentification optionnelle | app | Must | S | FAIT |
 | NT-042 | Profil utilisateur (nom/avatar/niveau) | both | Should | M | FAIT |
 | NT-043 | Endpoint `/users/me` | server | Must | S | FAIT |
-| NT-044 | Authentification OAuth Facebook | both | Could | M | À VÉRIFIER |
+| NT-044 | Authentification OAuth Facebook | both | Could | M | À FAIRE |
 | NT-045 | Stats publiques / partage de profil | both | Won't-now | M | À FAIRE |
 | NT-046 | Gamification | both | Won't-now | L | À FAIRE |
 | NT-047 | Apple Sign In | both | Won't-now | M | À FAIRE |
@@ -302,9 +302,9 @@
 ### NT-044 — Authentification OAuth Facebook
 - **Thème** : Auth & Compte · **Portée** : both · **Dépendances** : NT-040
 - **Description** : Se connecter avec Facebook.
-- **Critères d'acceptation** : serveur `/auth/facebook/*` fonctionnel ; **app : bouton Facebook câblé** (manquant aujourd'hui).
-- **Priorité** : Could · **Statut** : À VÉRIFIER.
-- **Notes** : **serveur = FAIT** (`api/auth_facebook.py`), **app = À FAIRE**, priorité basse (arbitrage 2026-07-07 : « plus tard, optionnelle »). Reste au backlog.
+- **Critères d'acceptation** : serveur `/auth/facebook/*` **validé de bout en bout** contre une vraie app Facebook (au-delà des tests mockés) ; **app : bouton Facebook câblé** (manquant aujourd'hui).
+- **Priorité** : Could · **Statut** : À FAIRE.
+- **Notes** : ⚠️ **non prioritaire**. Côté serveur, le **code est présent** (`api/auth_facebook.py` : `/start` + `/callback`, échange de code, Graph API) mais **reste à valider** de bout en bout : couvert uniquement par des tests mockés (`tests/test_oauth_flows.py`), pas encore éprouvé contre une vraie app Facebook (credentials non configurés). Côté app, aucun bouton Facebook. Statut global **À FAIRE** tant que le flow n'est pas câblé (app) et validé (serveur). Arbitrage 2026-07-07 : « plus tard, optionnelle ».
 
 ### NT-045 — Stats publiques / partage de profil
 - **Thème** : Auth & Compte · **Portée** : both · **Dépendances** : NT-042
@@ -641,7 +641,9 @@ TTL, compactage Hive automatique.
 - NT-023 dépend du format de sortie structuré du coach (à définir avec NT-033).
 - NT-024 et NT-015 exploitent les liens exercices ↔ sessions/objectifs déjà en
   place.
-- NT-044 a une valeur marginale (serveur déjà prêt, seul le bouton app manque).
+- NT-044 a une valeur marginale et reste **non prioritaire** : le code serveur
+  existe mais n'est pas validé de bout en bout (tests mockés seulement) et le
+  bouton app manque.
 
 **Critère de fin de sprint** : écran Coach multi-sessions fonctionnel, coach
 proposant des exercices structurés, stats d'usage, recommandations croisées,

--- a/docs/backlog/incoherences.md
+++ b/docs/backlog/incoherences.md
@@ -41,10 +41,10 @@
 - **Résolution (Claude, auto — le code fait foi).** Profil enrichi acté (NT-042 = FAIT). Le backlog v0.1 est périmé sur ce point.
 - **Impact.** NT-042 = FAIT ; `AGENTS.md` serveur + backlog serveur à corriger (I6).
 
-### I4 — Facebook : serveur prêt, app absente
-- **Constat.** Serveur : `api/auth_facebook.py` fonctionnel. App : seul `signInWithGoogle` est câblé (`auth_service.dart`).
-- **Résolution (utilisateur, 2026-07-07).** « Facebook plus tard, optionnelle » : reste au backlog en **priorité basse**.
-- **Impact.** NT-044 : serveur = FAIT, app = À FAIRE (Could). Statut global À VÉRIFIER tant que l'app n'est pas alignée.
+### I4 — Facebook : code serveur présent mais à valider, app absente
+- **Constat.** Serveur : `api/auth_facebook.py` contient le flow (`/start` + `/callback`, échange de code, Graph API) mais **reste à valider** — couvert uniquement par des **tests mockés** (`tests/test_oauth_flows.py`), pas encore éprouvé contre une vraie app Facebook (credentials non configurés). App : seul `signInWithGoogle` est câblé (`auth_service.dart`).
+- **Résolution (utilisateur, 2026-07-07, précisée 2026-07-13).** « Facebook plus tard, optionnelle » : **non prioritaire**. Le code serveur présent mais non validé ne compte pas comme livré.
+- **Impact.** NT-044 = **À FAIRE** (Could) des deux côtés : serveur à valider, app à câbler.
 
 ### I5 — Multi-personas coach : annoncé, non livré
 - **Constat.** L'ancien backlog app prévoit « coach neutre / coach cool ». Le code n'a qu'un `coach_neutre.yaml`, mais le paramètre `prompt_variant` et le mapping `_VARIANT_FILES` sont déjà en place (app + serveur).

--- a/docs/backlog/vue-app.md
+++ b/docs/backlog/vue-app.md
@@ -39,7 +39,7 @@
 | NT-040 | Authentification OAuth Google | both | Must | M | FAIT | `auth_service.dart`, `auth_provider` |
 | NT-041 | Authentification optionnelle | app | Must | S | FAIT | mode déconnecté préservé |
 | NT-042 | Profil utilisateur (nom/avatar/niveau) | both | Should | M | FAIT | `profile_screen.dart` — édition à vérifier |
-| NT-044 | Authentification OAuth Facebook | both | Could | M | À FAIRE | serveur prêt ; bouton app non câblé (basse prio) |
+| NT-044 | Authentification OAuth Facebook | both | Could | M | À FAIRE | serveur : code présent, à valider (tests mockés) ; bouton app non câblé ; non prioritaire |
 | NT-045 | Stats publiques / partage de profil | both | Won't-now | M | À FAIRE | — |
 | NT-046 | Gamification | both | Won't-now | L | À FAIRE | — |
 | NT-047 | Apple Sign In | both | Won't-now | M | À FAIRE | — |

--- a/docs/backlog/vue-serveur.md
+++ b/docs/backlog/vue-serveur.md
@@ -29,7 +29,7 @@
 | NT-040 | Authentification OAuth Google | both | Must | M | FAIT | `api/auth_google.py`, `/auth/token` |
 | NT-042 | Profil utilisateur (nom/avatar/niveau) | both | Should | M | FAIT | `models/user.py` (champs profil) |
 | NT-043 | Endpoint `/users/me` | server | Must | S | FAIT | `api/users.py` |
-| NT-044 | Authentification OAuth Facebook | both | Could | M | FAIT | `api/auth_facebook.py` (côté app : à câbler) |
+| NT-044 | Authentification OAuth Facebook | both | Could | M | À FAIRE | code `api/auth_facebook.py` présent, à valider (tests mockés seulement, non éprouvé contre une vraie app FB) ; côté app non câblé ; non prioritaire |
 | NT-045 | Stats publiques / partage de profil | both | Won't-now | M | À FAIRE | — |
 | NT-046 | Gamification | both | Won't-now | L | À FAIRE | — |
 | NT-047 | Apple Sign In | both | Won't-now | M | À FAIRE | roadmap v0.2 |


### PR DESCRIPTION
Le flow Facebook côté serveur (api/auth_facebook.py) existe mais n'est couvert que par des tests mockés, jamais éprouvé contre une vraie app Facebook ; côté app aucun bouton n'est câblé. On ne le compte donc plus comme livré.

- Statut NT-044 aligné à « À FAIRE » partout (backlog unifié + vues), au lieu de « À VÉRIFIER » / « FAIT côté serveur »
- Item marqué non prioritaire ; notes reformulées « code présent, à valider »
- incoherences.md I4 mis à jour (décision précisée le 2026-07-13)
- README : exemple de statut par côté déplacé de NT-044 vers NT-048

## Objet de la PR

- [ ] Analyse SonarCloud OK
- [ ] Tests unitaires verts
- [ ] Couverture >= 50% (objectif)
- [ ] Pas de secrets commités

## Description

Décrivez brièvement les changements, motivations, et impacts.

## Checklist

- [ ] `flutter test --coverage` exécuté en local
- [ ] `dart analyze` (optionnel) ne remonte pas d’erreurs
- [ ] Mise à jour des docs si nécessaire (README, specs)
- [ ] Cahier de recette mis à jour et recette manuelle validée
