### PR TITLE
feat(carnet-tir): NT-005 photo de cible + NT-007 filtre par exercice

### DIFF
--- a/docs/backlog/README.md
+++ b/docs/backlog/README.md
@@ -18,6 +18,7 @@ et ses vues dérivées. Il pilote le développement, y compris depuis Claude Cod
 | [`backlog-unifie.md`](backlog-unifie.md) | **LA source de vérité.** Tous les items produit (NT-XXX), groupés par thème. |
 | [`vue-app.md`](vue-app.md) | Projection des items de portée `app`/`both`. |
 | [`vue-serveur.md`](vue-serveur.md) | Projection des items de portée `server`/`both`. À copier dans le repo serveur. |
+| [`plan-sprints.md`](plan-sprints.md) | Vue de pilotage : tri métier + dépendances + planification par sprints livrables. |
 | [`incoherences.md`](incoherences.md) | Journal des écarts backlogs ⇄ code et des décisions. |
 
 ## Règle de synchronisation (impérative)

--- a/docs/backlog/backlog-unifie.md
+++ b/docs/backlog/backlog-unifie.md
@@ -662,6 +662,11 @@
 
 ## Backlog priorisé
 
+> ⚠️ **Plan historique.** Ce bloc reflète la planification établie avant
+> l'enrichissement des thèmes 10–13 et contient plusieurs items désormais
+> `FAIT`. Le plan courant de priorisation métier, dépendances et sprints
+> livrables est maintenu dans [`plan-sprints.md`](plan-sprints.md).
+
 > **Dernière mise à jour** : 2026-07-07.
 > Découpage en sprints de 2 semaines. Chaque sprint livre un produit (app +
 > serveur) cohérent, fonctionnel, sans régression. Les items FAIT ne figurent pas

--- a/docs/backlog/plan-sprints.md
+++ b/docs/backlog/plan-sprints.md
@@ -1,0 +1,197 @@
+# NexTarget — Plan de priorisation & sprints
+
+> Vue de pilotage dérivée du [`backlog-unifie.md`](backlog-unifie.md), établie le
+> 2026-07-13. Le backlog unifié reste la source de vérité produit ; ce document
+> ordonne les items non livrés par valeur métier, dépendances et capacité à
+> produire une version stable en fin de sprint.
+
+## Hypothèses
+
+- Sprints de 2 semaines.
+- Un sprint doit livrer une version utilisable en production, sans feature
+  incomplète exposée.
+- Les développements peuvent être parallélisés entre app Flutter et serveur
+  FastAPI quand les contrats sont clairs.
+- Les items `FAIT` ne sont pas replanifiés. Les items `Won't-now` restent en
+  Icebox, sauf décision produit contraire.
+- Le vieux plan S1-S6 dans le backlog unifié est considéré comme historique :
+  plusieurs items y sont déjà livrés et les thèmes 10-13 ajoutés le 2026-07-13
+  n'y sont pas encore ventilés.
+
+## Méthode de tri
+
+1. **Valeur métier** : priorité aux items qui rendent NexTarget plus utile pour
+   progresser en discipline officielle, surtout TAR 25 m.
+2. **Dépendances** : les socles structurants passent avant les écrans avancés
+   qui les consomment.
+3. **Stabilité livrable** : chaque sprint regroupe des features qui forment une
+   version cohérente, testable et exploitable.
+4. **Risque technique** : les migrations Hive, contrats coach structurés et
+   endpoints serveur sont isolés dans des sprints où la recette peut absorber le
+   risque.
+
+## Backlog ordonné
+
+| Rang | Items | Pourquoi maintenant | Dépendances clés | Portée |
+|---|---|---|---|---|
+| 1 | NT-100, NT-101 | Socle métier TAR : rend les sessions comparables et exploitables par stats/coach. | NT-001, NT-002 | app |
+| 2 | NT-073, NT-130 | Réduit fortement la friction de saisie au stand ; prépare les templates par épreuve. | NT-001, NT-101 optionnel | app |
+| 3 | NT-005, NT-110 | Photo cible exploitable : mémoire visuelle puis contexte fiable pour le coach. | NT-001, NT-100 | app |
+| 4 | NT-104 | Restitution immédiate de la progression par discipline. | NT-100, NT-010 | app |
+| 5 | NT-120, NT-121 | Donne un vrai écran Coach transverse, à forte valeur métier. | NT-101, NT-010, NT-030 | both |
+| 6 | NT-122 | Socle serveur pour que le coach produise des entités validables. | NT-031 | server |
+| 7 | NT-123, NT-124 | Le coach devient actionnable : exercices et objectifs proposés, validés par le tireur. | NT-122, NT-020, NT-012 | both |
+| 8 | NT-102, NT-131, NT-074 | Usage terrain avancé : match blanc, session live, saisie rapide. | NT-101, NT-130, NT-002 | app |
+| 9 | NT-111 | Analyse qualitative photo par IA, utile mais seulement après photos taguées et référentiel. | NT-005, NT-110, NT-100, NT-030 | both |
+| 10 | NT-125, NT-126 | Boucle longue : suivi des recommandations puis plan d'entraînement. | NT-121, NT-123, NT-124 | both |
+| 11 | NT-024, NT-015, NT-014, NT-016 | Raffinement stats/objectifs/exercices après les axes TAR et coach. | NT-022, NT-021, NT-010, NT-012 | app |
+| 12 | NT-056, NT-057, NT-076 | Dette qualité/performance app, à caler dans un sprint de stabilisation. | — | app |
+| 13 | NT-034, NT-025, NT-007 | Améliorations utiles mais non structurantes. | NT-032, NT-020, NT-022 | app/server |
+| 14 | NT-044, NT-103, NT-132 | Opportunistes ou à instruire : Facebook, grilles FFTir, spike vocal. | sourcing/config terrain | both/app |
+| Infra | NT-071 | À déclencher avant multi-instance ou montée de charge serveur, pas bloquant pour le cycle fonctionnel court. | — | server |
+
+## Plan par sprint
+
+### Sprint 1 — Socle TAR & saisie rapide
+
+**Objectif livrable** : l'utilisateur peut créer des sessions typées discipline
+TAR, avec calibres normalisés et création rapide depuis un setup favori.
+
+| Ordre | Item | Feature | App | Serveur |
+|---|---|---|---|---|
+| 1 | NT-100 | Référentiel TAR 25 m versionné | seed YAML, services de lecture | — |
+| 2 | NT-101 | Sessions et séries typées discipline | migrations Hive, formulaires, scoring essai/précision/vitesse/gongs | — |
+| 3 | NT-073 | Normalisation calibres + dernier calibre | référentiel calibres, pré-remplissage | — |
+| 4 | NT-130 | Templates de session | dernier setup, favoris, création en 2 taps | — |
+
+**Version stable attendue** : aucun écran coach nouveau ; focus carnet. Les
+sessions existantes restent lisibles après migration.
+
+### Sprint 2 — Restitution TAR & photo cible
+
+**Objectif livrable** : le tireur voit ses stats par discipline et peut conserver
+des photos de cible correctement contextualisées.
+
+| Ordre | Item | Feature | App | Serveur |
+|---|---|---|---|---|
+| 1 | NT-104 | Stats & records par discipline | filtres, records par épreuve, dashboard distinct | — |
+| 2 | NT-005 | Photo de cible sur session | prise/sélection, stockage local, détail session | — |
+| 3 | NT-110 | Métadonnées cible & photo par série | cible/distance/série associée | — |
+
+**Version stable attendue** : photos seulement locales et taguées ; aucune
+analyse IA photo encore exposée.
+
+### Sprint 3 — Coach progression v1
+
+**Objectif livrable** : remplacer le placeholder Coach par une analyse transverse
+réelle, bornée en taille et exploitable par discipline.
+
+| Ordre | Item | Feature | App | Serveur |
+|---|---|---|---|---|
+| 1 | NT-120 | Payload d'analyse transverse compact | agrégats locaux, N dernières sessions, fenêtre 90 j | contrat d'entrée validé |
+| 2 | NT-121 | Écran Coach : analyse de progression | écran Coach, états loading/error, rendu analyse | endpoint analyse progression, prompt serveur |
+| 3 | NT-034 | Affinage prompts personas | recette app des tons | prompts neutre/cool ajustés |
+
+**Version stable attendue** : le coach conseille sur la progression, sans créer
+automatiquement d'exercices ni d'objectifs.
+
+### Sprint 4 — Coach actionnable
+
+**Objectif livrable** : le coach propose des entités structurées, mais le tireur
+garde toujours la main avant création.
+
+| Ordre | Item | Feature | App | Serveur |
+|---|---|---|---|---|
+| 1 | NT-122 | Sortie coach structurée | alignement modèles Exercise/Goal | JSON schema versionné, validation, fallback |
+| 2 | NT-123 | Coach propose des exercices | prévisualisation, édition, déduplication, insertion catalogue | génération structurée exercice |
+| 3 | NT-124 | Coach propose des objectifs | prévisualisation, édition, lien exercices | génération structurée objectif |
+
+**Version stable attendue** : aucune création sans validation explicite ; les
+sorties invalides retombent proprement en analyse texte.
+
+### Sprint 5 — Usage stand avancé
+
+**Objectif livrable** : l'app devient utilisable pendant l'entraînement, pas
+seulement après la séance.
+
+| Ordre | Item | Feature | App | Serveur |
+|---|---|---|---|---|
+| 1 | NT-102 | Mode match blanc TAR | déroulé guidé 830/831/832, chronos, score /200 | — |
+| 2 | NT-131 | Session live au stand | statut en cours, saisie série par série, chrono repos | — |
+| 3 | NT-074 | Saisie séries plein écran | navigation rapide, numpad/swipe | — |
+
+**Version stable attendue** : les sessions live se clôturent en sessions standard
+et restent compatibles avec stats, historique et coach.
+
+### Sprint 6 — Analyse photo qualitative
+
+**Objectif livrable** : le coach enrichit son diagnostic avec la photo de cible,
+sans prétendre remplacer la saisie manuelle.
+
+| Ordre | Item | Feature | App | Serveur |
+|---|---|---|---|---|
+| 1 | NT-111 | Analyse qualitative photo par coach multimodal | envoi photo taguée, rendu analyse, cas photo inexploitable | endpoint multimodal JWT, rate limit, prompt cible |
+| 2 | NT-056 | Harmonisation erreurs réseau | messages homogènes auth/profil/coach/photo | contrats d'erreur stables |
+
+**Version stable attendue** : analyse qualitative seulement ; NT-006 reste en
+Icebox tant que l'extraction métrique n'a pas prouvé sa valeur.
+
+### Sprint 7 — Boucle de progression
+
+**Objectif livrable** : les recommandations du coach deviennent suivables et
+mesurables dans le temps.
+
+| Ordre | Item | Feature | App | Serveur |
+|---|---|---|---|---|
+| 1 | NT-125 | Suivi des recommandations | statut suivie/non suivie, consultation | réinjection dans contexte coach |
+| 2 | NT-024 | Stats d'exécution exercices | usageCount, lastPerformedAt, fenêtres glissantes | — |
+| 3 | NT-015 | Recos Objectifs ⇄ Exercices | suggestions locales selon objectifs en retard | — |
+
+**Version stable attendue** : le coach voit si ses conseils ont été appliqués,
+mais aucun plan multi-semaines automatique.
+
+### Sprint 8 — Plan d'entraînement & stats fines
+
+**Objectif livrable** : générer un plan 2-4 semaines validé par le tireur, puis
+compléter les raffinements statistiques.
+
+| Ordre | Item | Feature | App | Serveur |
+|---|---|---|---|---|
+| 1 | NT-126 | Plan d'entraînement | prévisualisation, validation, création sessions/exercices/objectifs | génération plan structurée |
+| 2 | NT-014 | Comparatif 30 j vs 60 j + sparkline | dashboard enrichi | — |
+| 3 | NT-016 | Objectifs enrichis | statuts étendus, journal, vue détail, migration | — |
+
+**Version stable attendue** : le plan est optionnel, validé avant création et
+réversible par suppression des entités créées.
+
+## Sprints de stabilisation ou opportunistes
+
+| Déclencheur | Items | Recommandation |
+|---|---|---|
+| Avant ouverture publique plus large ou multi-instance Render | NT-071 | Migrer SQLite vers Postgres + Alembic avant de dépendre d'un rate-limit/state partagé. |
+| Dette UI ou baisse de maintenabilité | NT-057, NT-076 | Planifier un sprint court de nettoyage/performance sans nouvelle feature métier. |
+| Besoin login social autre que Google | NT-044 | Valider le flow Facebook contre une vraie app Facebook puis câbler le bouton app. |
+| Besoin classement officiel fédéral | NT-103 | Sourcer les grilles RGS FFTir avant estimation définitive. |
+| Hypothèse de saisie mains libres au stand | NT-132 | Spike timeboxé uniquement, avec go/no-go en conditions réelles. |
+| Besoin de confort catalogue exercices | NT-025, NT-007 | À insérer dans un sprint app si faible coût réel confirmé. |
+
+## Icebox
+
+| Item | Raison |
+|---|---|
+| NT-006 | Analyse métrique CV coûteuse ; NT-111 doit d'abord valider la valeur de l'analyse photo. |
+| NT-045 | Partage public sans demande métier actuelle. |
+| NT-046 | Gamification large, risque de dispersion. |
+| NT-047 | Apple Sign In à reconsidérer seulement avec stratégie iOS/App Store et logins sociaux. |
+| NT-090 | Cosmétique. |
+| NT-091 | À réouvrir seulement avec besoin réglementaire clair. |
+
+## Points de cohérence à corriger
+
+- `vue-serveur.md` indique encore NT-032 à faire alors que le backlog unifié le
+  marque `FAIT`. La projection serveur doit être resynchronisée.
+- Les "Prochaines actions serveur" de `vue-serveur.md` listent plusieurs items
+  déjà `FAIT` dans le backlog unifié (`NT-048`, `NT-053`, `NT-054`, `NT-055`).
+- Le bloc "Backlog priorisé" du backlog unifié est historique et mélange items
+  livrés, anciens sprints et nouveaux thèmes. Il devrait être remplacé par un
+  lien vers ce plan ou régénéré depuis celui-ci après validation produit.

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -49,6 +49,10 @@
 	<true/>
 	<key>UIViewControllerBasedStatusBarAppearance</key>
 	<false/>
+	<key>NSCameraUsageDescription</key>
+	<string>NexTarget utilise l'appareil photo pour prendre en photo la cible en fin de session de tir.</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>NexTarget accède à vos photos pour attacher une photo de la cible à une session de tir.</string>
 	<key>CFBundleURLTypes</key>
 	<array>
 		<dict>

--- a/lib/interfaces/session_photo_service_interface.dart
+++ b/lib/interfaces/session_photo_service_interface.dart
@@ -1,0 +1,16 @@
+import 'package:image_picker/image_picker.dart';
+
+/// Interface pour le service de gestion de la photo de cible attachée à une session (NT-005).
+///
+/// Abstraction permettant de mocker facilement la sélection/prise de photo dans les tests
+/// (le plugin image_picker ne peut pas être exercé dans un environnement de test headless).
+abstract class ISessionPhotoService {
+  /// Ouvre la galerie ou l'appareil photo selon [source], copie le fichier sélectionné
+  /// dans un répertoire persistant de l'application et retourne le chemin absolu du
+  /// fichier stocké. Retourne `null` si l'utilisateur annule la sélection.
+  Future<String?> pickAndStore(ImageSource source);
+
+  /// Supprime le fichier photo à l'emplacement [path] s'il existe. Ne fait rien si
+  /// [path] est `null`/vide ou si le fichier est déjà absent.
+  Future<void> deleteIfExists(String? path);
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -9,6 +9,7 @@ import 'models/goal.dart';
 import 'migrations/migration.dart';
 import 'migrations/migration_2_add_exercises_field.dart';
 import 'migrations/migration_3_create_exercises_box.dart';
+import 'migrations/migration_4_add_photo_path_field.dart';
 import 'constants/session_constants.dart';
 import 'providers/navigation_provider.dart';
 import 'providers/settings_provider.dart';
@@ -35,6 +36,7 @@ Future<void> main() async {
   final runner = MigrationRunner([
     Migration2AddExercisesField(), // v2
     Migration3CreateExercisesBox(), // v3
+    Migration4AddPhotoPathField(), // v4
   ], schemaStore);
   await runner.run();
   

--- a/lib/migrations/migration_4_add_photo_path_field.dart
+++ b/lib/migrations/migration_4_add_photo_path_field.dart
@@ -1,0 +1,28 @@
+import 'package:hive/hive.dart';
+import 'migration.dart';
+
+/// Migration v4: ensure each session map has a 'photoPath' key (null if absent).
+/// Support de NT-005 (photo de la cible attachée à la session).
+class Migration4AddPhotoPathField extends HiveMigration {
+  @override
+  int get toVersion => 4;
+
+  @override
+  Future<void> apply() async {
+    // Sessions stored in 'sessions' box as maps {session: {...}, series: [...]}
+    if (!Hive.isBoxOpen('sessions')) return; // nothing to do if not opened yet
+    final box = Hive.box('sessions');
+    final keys = box.keys.toList();
+    for (final k in keys) {
+      final raw = box.get(k);
+      if (raw is Map) {
+        final map = Map<String, dynamic>.from(raw);
+        final session = Map<String, dynamic>.from(map['session']);
+        // Add photoPath key if missing, sans écraser une valeur existante.
+        session.putIfAbsent('photoPath', () => null);
+        map['session'] = session;
+        await box.put(k, map);
+      }
+    }
+  }
+}

--- a/lib/models/shooting_session.dart
+++ b/lib/models/shooting_session.dart
@@ -11,6 +11,7 @@ class ShootingSession {
   String? synthese;
   String category; // entraînement / match / test matériel
   List<String> exercises; // exercise IDs linked to this session (can be empty)
+  String? photoPath; // chemin local (persistant) de la photo de la cible (NT-005)
 
   ShootingSession({
     this.id,
@@ -23,6 +24,7 @@ class ShootingSession {
     this.synthese,
     this.category = 'entraînement',
     List<String>? exercises,
+    this.photoPath,
   }) : exercises = exercises ?? <String>[];
 
   Map<String, dynamic> toMap() {
@@ -37,6 +39,7 @@ class ShootingSession {
       'synthese': synthese,
       'category': category,
       'exercises': exercises,
+      'photoPath': photoPath,
     };
   }
 
@@ -59,8 +62,12 @@ class ShootingSession {
       exercises: (map['exercises'] is List)
           ? (map['exercises'] as List).whereType<String>().toList()
           : <String>[],
+      photoPath: map['photoPath'] as String?,
     );
   }
+
+  /// Indique si une photo de la cible est associée à cette session
+  bool get hasPhoto => (photoPath != null && photoPath!.trim().isNotEmpty);
 
   /// Indique si une analyse coach est disponible
   bool get hasAnalysis => (analyse != null && analyse!.trim().isNotEmpty);

--- a/lib/screens/session_detail/session_detail_components.dart
+++ b/lib/screens/session_detail/session_detail_components.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_markdown/flutter_markdown.dart';
 import 'package:provider/provider.dart';
@@ -426,6 +427,87 @@ class SessionSyntheseSection extends StatelessWidget {
               style: Theme.of(context).textTheme.bodyMedium,
             ),
           ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Section photo de la cible (NT-005)
+class SessionPhotoSection extends StatelessWidget {
+  final String photoPath;
+
+  /// Permet d'injecter un [ImageProvider] alternatif (utilisé par les tests
+  /// widgets pour éviter le décodage réel de fichier via [FileImage], qui ne
+  /// se résout jamais en environnement headless). Par défaut, comportement
+  /// inchangé : [FileImage] sur [photoPath].
+  final ImageProvider Function(String path)? imageProviderBuilder;
+
+  const SessionPhotoSection({
+    super.key,
+    required this.photoPath,
+    this.imageProviderBuilder,
+  });
+
+  ImageProvider _resolveImageProvider() =>
+      (imageProviderBuilder ?? (path) => FileImage(File(path)))(photoPath);
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      elevation: 1,
+      shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(14)),
+      child: Padding(
+        padding: const EdgeInsets.all(12.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: [
+                Icon(Icons.photo_camera_outlined, size: 18, color: Theme.of(context).colorScheme.secondary),
+                const SizedBox(width: 8),
+                const Text('Photo de la cible', style: TextStyle(fontWeight: FontWeight.bold)),
+              ],
+            ),
+            const SizedBox(height: 10),
+            ClipRRect(
+              borderRadius: BorderRadius.circular(12),
+              child: GestureDetector(
+                onTap: () => _showFullScreen(context),
+                child: Image(
+                  image: _resolveImageProvider(),
+                  width: double.infinity,
+                  height: 220,
+                  fit: BoxFit.cover,
+                  errorBuilder: (context, error, stackTrace) => Container(
+                    width: double.infinity,
+                    height: 120,
+                    color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.06),
+                    alignment: Alignment.center,
+                    child: const Text('Photo introuvable'),
+                  ),
+                ),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  void _showFullScreen(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (ctx) => Dialog(
+        insetPadding: const EdgeInsets.all(12),
+        child: InteractiveViewer(
+          child: Image(
+            image: _resolveImageProvider(),
+            errorBuilder: (context, error, stackTrace) => const Padding(
+              padding: EdgeInsets.all(24.0),
+              child: Text('Photo introuvable'),
+            ),
+          ),
         ),
       ),
     );

--- a/lib/screens/session_detail_screen.dart
+++ b/lib/screens/session_detail_screen.dart
@@ -137,6 +137,10 @@ class _SessionDetailScreenState extends State<SessionDetailScreen> {
         padding: EdgeInsets.all(16),
         children: [
           SessionHeaderCard(session: session, series: series, planned: isPlanned),
+          if (session.hasPhoto) ...[
+            SizedBox(height: 16),
+            SessionPhotoSection(photoPath: session.photoPath!),
+          ],
           if (session.exercises.isNotEmpty) ...[
             SizedBox(height: 16),
             SessionExercisesSection(

--- a/lib/screens/sessions_history_screen.dart
+++ b/lib/screens/sessions_history_screen.dart
@@ -1,9 +1,12 @@
 import '../widgets/session_card.dart';
 import 'package:flutter/material.dart';
 import '../services/session_service.dart';
+import '../services/exercise_service.dart';
 import '../constants/session_constants.dart';
 import 'session_detail_screen.dart';
 import '../models/shooting_session.dart';
+import '../models/exercise.dart';
+import '../utils/session_filters.dart';
 
 
 class SessionsHistoryScreen extends StatefulWidget {
@@ -15,8 +18,11 @@ class SessionsHistoryScreen extends StatefulWidget {
 
 class SessionsHistoryScreenState extends State<SessionsHistoryScreen> {
   final SessionService _sessionService = SessionService();
-  late Future<List<ShootingSession>> _sessionsFuture;
+  final ExerciseService _exerciseService = ExerciseService();
+  late Future<(List<ShootingSession>, List<Exercise>)> _dataFuture;
   String _filter = 'realized'; // realized | planned
+  // Filtre exercice (NT-007), combinable avec _filter. null = "Tous les exercices".
+  String? _exerciseFilter;
 
   /// Onglet actif, exposé pour que le bouton + (AppNavigator) crée une
   /// session du même statut que l'onglet affiché.
@@ -30,8 +36,14 @@ class SessionsHistoryScreenState extends State<SessionsHistoryScreen> {
 
   void refreshSessions() {
     setState(() {
-      _sessionsFuture = _sessionService.getAllSessions();
+      _dataFuture = _loadData();
     });
+  }
+
+  Future<(List<ShootingSession>, List<Exercise>)> _loadData() async {
+    final sessions = await _sessionService.getAllSessions();
+    final exercises = await _exerciseService.listAll();
+    return (sessions, exercises);
   }
 
   @override
@@ -42,15 +54,23 @@ class SessionsHistoryScreenState extends State<SessionsHistoryScreen> {
 
   @override
   Widget build(BuildContext context) {
-    return FutureBuilder<List<ShootingSession>>(
-        future: _sessionsFuture,
+    return FutureBuilder<(List<ShootingSession>, List<Exercise>)>(
+        future: _dataFuture,
         builder: (context, snapshot) {
           if (snapshot.connectionState == ConnectionState.waiting) {
             return Center(child: CircularProgressIndicator());
           }
-      final all = (snapshot.data ?? []);
-      final realizedAll = all.where((s) => (s.status == SessionConstants.statusRealisee) && (s.date != null)).toList();
-      final plannedAll = all.where((s) => s.status == SessionConstants.statusPrevue).toList();
+      final all = snapshot.data?.$1 ?? <ShootingSession>[];
+      final exercises = snapshot.data?.$2 ?? <Exercise>[];
+      // Un exercice lié à une session peut avoir été supprimé depuis (aucune
+      // suppression en cascade côté ExerciseService) : si le filtre actif ne
+      // correspond plus à un exercice existant, on retombe silencieusement
+      // sur "Tous les exercices" plutôt que de planter le DropdownButtonFormField.
+      final effectiveExerciseFilter = exercises.any((e) => e.id == _exerciseFilter) ? _exerciseFilter : null;
+      final bool hasExerciseFilter = effectiveExerciseFilter != null;
+      final exerciseFiltered = SessionFilters.byExercise(all, effectiveExerciseFilter);
+      final realizedAll = exerciseFiltered.where((s) => (s.status == SessionConstants.statusRealisee) && (s.date != null)).toList();
+      final plannedAll = exerciseFiltered.where((s) => s.status == SessionConstants.statusPrevue).toList();
 
       List<ShootingSession> sessions = realizedAll;
       List<ShootingSession> planned = plannedAll;
@@ -116,6 +136,27 @@ class SessionsHistoryScreenState extends State<SessionsHistoryScreen> {
                             ],
                           ),
                         ),
+                        Padding(
+                          padding: const EdgeInsets.fromLTRB(16, 0, 16, 8),
+                          child: DropdownButtonFormField<String?>(
+                            initialValue: effectiveExerciseFilter,
+                            isExpanded: true,
+                            decoration: const InputDecoration(
+                              labelText: 'Filtrer par exercice',
+                              prefixIcon: Icon(Icons.filter_alt_outlined),
+                              isDense: true,
+                              border: OutlineInputBorder(),
+                            ),
+                            items: [
+                              const DropdownMenuItem<String?>(value: null, child: Text('Tous les exercices')),
+                              ...exercises.map((e) => DropdownMenuItem<String?>(
+                                    value: e.id,
+                                    child: Text(e.name, overflow: TextOverflow.ellipsis),
+                                  )),
+                            ],
+                            onChanged: (id) => setState(() => _exerciseFilter = id),
+                          ),
+                        ),
                         if (_filter == 'realized')
                           _SummaryHeader(nbSessions: nbSessions, totalSeries: totalSeries, avgSeries: avgSeries, daysActive: daysActive)
                         else
@@ -137,9 +178,13 @@ class SessionsHistoryScreenState extends State<SessionsHistoryScreen> {
                           children: [
                             Icon(Icons.pending_actions, size: 48, color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.24)),
                             SizedBox(height: 12),
-                            Text('Aucune session prévue', style: TextStyle(fontWeight: FontWeight.w600)),
+                            Text(hasExerciseFilter ? 'Aucune session prévue pour cet exercice' : 'Aucune session prévue', style: TextStyle(fontWeight: FontWeight.w600)),
                             SizedBox(height: 8),
-                            Text('Crée une session prévue depuis le +', textAlign: TextAlign.center, style: TextStyle(fontSize: 12, color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6))),
+                            Text(
+                              hasExerciseFilter ? 'Essaie un autre exercice ou réinitialise le filtre.' : 'Crée une session prévue depuis le +',
+                              textAlign: TextAlign.center,
+                              style: TextStyle(fontSize: 12, color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6)),
+                            ),
                           ],
                         ),
                       );
@@ -154,9 +199,13 @@ class SessionsHistoryScreenState extends State<SessionsHistoryScreen> {
                           children: [
                             Icon(Icons.insights_outlined, size: 48, color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.24)),
                             SizedBox(height: 12),
-                            Text('Aucune session réalisée', style: TextStyle(fontWeight: FontWeight.w600)),
+                            Text(hasExerciseFilter ? 'Aucune session réalisée pour cet exercice' : 'Aucune session réalisée', style: TextStyle(fontWeight: FontWeight.w600)),
                             SizedBox(height: 8),
-                            Text('Utilise le bouton + pour ajouter ta première.', textAlign: TextAlign.center, style: TextStyle(fontSize: 12, color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6))),
+                            Text(
+                              hasExerciseFilter ? 'Essaie un autre exercice ou réinitialise le filtre.' : 'Utilise le bouton + pour ajouter ta première.',
+                              textAlign: TextAlign.center,
+                              style: TextStyle(fontSize: 12, color: Theme.of(context).colorScheme.onSurface.withValues(alpha: 0.6)),
+                            ),
                           ],
                         ),
                       );

--- a/lib/services/session_photo_service.dart
+++ b/lib/services/session_photo_service.dart
@@ -1,0 +1,64 @@
+import 'dart:io';
+import 'package:image_picker/image_picker.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:uuid/uuid.dart';
+import '../interfaces/session_photo_service_interface.dart';
+import 'logger.dart';
+
+/// Implémentation par défaut de [ISessionPhotoService], basée sur `image_picker`
+/// (galerie + appareil photo) et `path_provider` (répertoire de documents de l'app).
+///
+/// Les chemins retournés par `image_picker` peuvent pointer vers un cache éphémère :
+/// le fichier sélectionné/pris est donc copié dans un sous-dossier persistant des
+/// documents de l'app, sous un nom unique et stable, pour survivre au redémarrage
+/// de l'app (cf. NT-005).
+class SessionPhotoService implements ISessionPhotoService {
+  static const _subDir = 'session_photos';
+
+  final ImagePicker _picker;
+
+  SessionPhotoService({ImagePicker? picker}) : _picker = picker ?? ImagePicker();
+
+  @override
+  Future<String?> pickAndStore(ImageSource source) async {
+    try {
+      final XFile? picked = await _picker.pickImage(source: source, imageQuality: 85);
+      if (picked == null) return null;
+      return _storeFile(picked.path);
+    } catch (e) {
+      AppLogger.I.error('Erreur lors de la sélection/prise de la photo cible', e);
+      return null;
+    }
+  }
+
+  @override
+  Future<void> deleteIfExists(String? path) async {
+    if (path == null || path.trim().isEmpty) return;
+    try {
+      final file = File(path);
+      if (await file.exists()) {
+        await file.delete();
+      }
+    } catch (e) {
+      AppLogger.I.error('Erreur lors de la suppression de la photo cible', e);
+    }
+  }
+
+  Future<String> _storeFile(String sourcePath) async {
+    final docsDir = await getApplicationDocumentsDirectory();
+    final targetDir = Directory('${docsDir.path}/$_subDir');
+    if (!await targetDir.exists()) {
+      await targetDir.create(recursive: true);
+    }
+    final fileName = 'target_${const Uuid().v4()}${_extensionOf(sourcePath)}';
+    final targetPath = '${targetDir.path}/$fileName';
+    await File(sourcePath).copy(targetPath);
+    return targetPath;
+  }
+
+  String _extensionOf(String path) {
+    final dotIndex = path.lastIndexOf('.');
+    if (dotIndex == -1 || dotIndex == path.length - 1) return '.jpg';
+    return path.substring(dotIndex);
+  }
+}

--- a/lib/services/session_service.dart
+++ b/lib/services/session_service.dart
@@ -2,14 +2,19 @@ import '../models/shooting_session.dart';
 import '../repositories/session_repository.dart';
 import '../repositories/hive_session_repository.dart';
 import '../interfaces/session_service_interface.dart';
+import '../interfaces/session_photo_service_interface.dart';
 import 'logger.dart';
 import '../models/exercise.dart';
 import '../models/series.dart';
+import 'session_photo_service.dart';
 
 class SessionService implements ISessionService {
   final SessionRepository _repo;
+  final ISessionPhotoService _photoService;
 
-  SessionService({SessionRepository? repository}) : _repo = repository ?? HiveSessionRepository();
+  SessionService({SessionRepository? repository, ISessionPhotoService? photoService})
+      : _repo = repository ?? HiveSessionRepository(),
+        _photoService = photoService ?? SessionPhotoService();
 
   @override
   Future<List<ShootingSession>> getAllSessions() async {
@@ -30,6 +35,9 @@ class SessionService implements ISessionService {
     bool preserveExistingSeriesIfEmpty = true,
     bool warnOnFallback = true,
   }) async {
+    // Capture l'ancienne photo (si existante) avant écrasement, pour pouvoir nettoyer
+    // le fichier local si elle a été remplacée ou supprimée par cette mise à jour.
+    final previousPhotoPath = await _findPhotoPath(session.id);
     final fallback = await _repo.update(
       session,
       preserveExistingSeriesIfEmpty: preserveExistingSeriesIfEmpty,
@@ -37,17 +45,45 @@ class SessionService implements ISessionService {
     if (fallback && warnOnFallback) {
       AppLogger.I.warn('Session ${session.id} update used fallback (empty series ignored).');
     }
+    if (previousPhotoPath != null && previousPhotoPath != session.photoPath) {
+      await _photoService.deleteIfExists(previousPhotoPath);
+    }
   }
 
   @override
   Future<void> deleteSession(int id) async {
+    final photoPath = await _findPhotoPath(id);
     await _repo.delete(id);
+    if (photoPath != null) {
+      await _photoService.deleteIfExists(photoPath);
+    }
   }
 
   @override
   Future<void> clearAllSessions() async {
     AppLogger.I.debug('Clearing all sessions');
+    try {
+      final all = await _repo.getAll();
+      for (final s in all) {
+        if (s.hasPhoto) await _photoService.deleteIfExists(s.photoPath);
+      }
+    } catch (e) {
+      AppLogger.I.error('Erreur lors du nettoyage des photos avant purge des sessions', e);
+    }
     await _repo.clearAll();
+  }
+
+  /// Récupère le photoPath actuellement persisté pour la session [sessionId], si connu.
+  Future<String?> _findPhotoPath(int? sessionId) async {
+    if (sessionId == null) return null;
+    try {
+      final all = await _repo.getAll();
+      final match = all.where((s) => s.id == sessionId);
+      return match.isEmpty ? null : match.first.photoPath;
+    } catch (e) {
+      AppLogger.I.error('Erreur lors de la récupération de la photo existante', e);
+      return null;
+    }
   }
 
   /// Convert a planned session (status 'prévue') into a realized one.

--- a/lib/utils/session_filters.dart
+++ b/lib/utils/session_filters.dart
@@ -9,4 +9,13 @@ class SessionFilters {
         .where((s) => s.status == SessionConstants.statusRealisee && s.date != null)
         .toList();
   }
+
+  /// Keep only sessions on which the given exercise was worked (NT-007).
+  ///
+  /// If [exerciseId] is null, no filtering is applied and every session is
+  /// returned unchanged (this represents the "all exercises" selection).
+  static List<ShootingSession> byExercise(Iterable<ShootingSession> sessions, String? exerciseId) {
+    if (exerciseId == null) return sessions.toList();
+    return sessions.where((s) => s.exercises.contains(exerciseId)).toList();
+  }
 }

--- a/lib/widgets/session_form.dart
+++ b/lib/widgets/session_form.dart
@@ -1,5 +1,6 @@
 import '../forms/series_form_controllers.dart';
 import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
 import '../forms/series_form_data.dart';
 import '../services/preferences_service.dart';
 import '../utils/caliber_autocomplete.dart';
@@ -10,13 +11,22 @@ import '../constants/session_constants.dart';
 import '../models/series.dart';
 import '../models/exercise.dart';
 import '../services/exercise_service.dart';
+import '../interfaces/session_photo_service_interface.dart';
+import '../services/session_photo_service.dart';
 import 'session_form/session_form_components.dart';
 
 class SessionForm extends StatefulWidget {
   final Map<String, dynamic>? initialSessionData;
   final void Function(ShootingSession session) onSave;
   final bool isEdit;
-  const SessionForm({super.key, this.initialSessionData, required this.onSave, this.isEdit = false});
+  final ISessionPhotoService? photoService;
+  const SessionForm({
+    super.key,
+    this.initialSessionData,
+    required this.onSave,
+    this.isEdit = false,
+    this.photoService,
+  });
 
   static SessionFormState? of(BuildContext context) {
     return context.findAncestorStateOfType<SessionFormState>();
@@ -44,6 +54,11 @@ class SessionFormState extends State<SessionForm> {
   List<Exercise> _allExercises = [];
   final Set<String> _selectedExerciseIds = <String>{};
   bool _loadingExercises = true;
+  // Photo de la cible (NT-005)
+  late final ISessionPhotoService _photoService = widget.photoService ?? SessionPhotoService();
+  String? _photoPath;
+  String? _initialPhotoPath;
+  bool _photoBusy = false;
 
   @override
   void initState() {
@@ -61,6 +76,8 @@ class SessionFormState extends State<SessionForm> {
   _syntheseController = TextEditingController(text: session['synthese'] ?? '');
   _category = session['category'] ?? SessionConstants.categoryEntrainement;
   _status = session['status'] ?? SessionConstants.statusRealisee;
+  _photoPath = session['photoPath'] as String?;
+  _initialPhotoPath = _photoPath;
       // Preload existing exercises list from session map if any
       final existingEx = session['exercises'];
       if (existingEx is List) {
@@ -123,6 +140,36 @@ class SessionFormState extends State<SessionForm> {
     });
     // Load exercises asynchronously
     _loadExercises();
+  }
+
+  /// Ouvre la galerie ou l'appareil photo, stocke la photo choisie localement
+  /// et remplace la photo précédemment sélectionnée dans ce formulaire (le cas
+  /// échéant). La photo déjà persistée en base (si édition) n'est nettoyée
+  /// qu'après un enregistrement réussi, côté [SessionService.updateSession].
+  Future<void> _pickPhoto(ImageSource source) async {
+    setState(() => _photoBusy = true);
+    try {
+      final newPath = await _photoService.pickAndStore(source);
+      if (newPath == null) return;
+      final oldPath = _photoPath;
+      // Ne supprimer immédiatement que les fichiers temporaires créés pendant
+      // cette édition (jamais persistés) ; la photo initiale reste intacte
+      // tant que l'utilisateur n'a pas confirmé l'enregistrement du formulaire.
+      if (oldPath != null && oldPath != _initialPhotoPath) {
+        await _photoService.deleteIfExists(oldPath);
+      }
+      if (mounted) setState(() => _photoPath = newPath);
+    } finally {
+      if (mounted) setState(() => _photoBusy = false);
+    }
+  }
+
+  Future<void> _removePhoto() async {
+    final oldPath = _photoPath;
+    if (oldPath != null && oldPath != _initialPhotoPath) {
+      await _photoService.deleteIfExists(oldPath);
+    }
+    if (mounted) setState(() => _photoPath = null);
   }
 
   Future<void> _loadExercises() async {
@@ -236,6 +283,7 @@ class SessionFormState extends State<SessionForm> {
       synthese: _syntheseController.text,
       category: _category,
       exercises: _selectedExerciseIds.toList(),
+      photoPath: _photoPath,
     );
     widget.onSave(session);
     return true;
@@ -460,6 +508,14 @@ class SessionFormState extends State<SessionForm> {
             ),
           ),
           SizedBox(height: 28),
+          SessionPhotoField(
+            photoPath: _photoPath,
+            isBusy: _photoBusy,
+            onPickFromGallery: () => _pickPhoto(ImageSource.gallery),
+            onPickFromCamera: () => _pickPhoto(ImageSource.camera),
+            onRemove: _removePhoto,
+          ),
+          SizedBox(height: 24),
           SyntheseCard(
             controller: _syntheseController,
             status: _status,

--- a/lib/widgets/session_form/session_form_components.dart
+++ b/lib/widgets/session_form/session_form_components.dart
@@ -1,3 +1,4 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
 
 /// Composants réutilisables pour session_form
@@ -313,6 +314,129 @@ class ExercisesSelector extends StatelessWidget {
                   onSelected: (_) => onToggle(ex.id),
                 );
               }).toList(),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+/// Sélecteur/aperçu de la photo de la cible attachée à la session (NT-005).
+/// Propose systématiquement les deux modes de capture (galerie ET appareil photo).
+class SessionPhotoField extends StatelessWidget {
+  final String? photoPath;
+  final bool isBusy;
+  final VoidCallback onPickFromGallery;
+  final VoidCallback onPickFromCamera;
+  final VoidCallback onRemove;
+
+  /// Permet d'injecter un [ImageProvider] alternatif (utilisé par les tests
+  /// widgets pour éviter le décodage réel de fichier via [FileImage], qui ne
+  /// se résout jamais en environnement headless). Par défaut, comportement
+  /// inchangé : [FileImage] sur [photoPath].
+  final ImageProvider Function(String path)? imageProviderBuilder;
+
+  const SessionPhotoField({
+    super.key,
+    required this.photoPath,
+    required this.onPickFromGallery,
+    required this.onPickFromCamera,
+    required this.onRemove,
+    this.isBusy = false,
+    this.imageProviderBuilder,
+  });
+
+  bool get _hasPhoto => photoPath != null && photoPath!.trim().isNotEmpty;
+
+  ImageProvider _resolveImageProvider() =>
+      (imageProviderBuilder ?? (path) => FileImage(File(path)))(photoPath!);
+
+  @override
+  Widget build(BuildContext context) {
+    return Card(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            Row(
+              children: const [
+                Icon(Icons.photo_camera_outlined, color: Colors.amberAccent, size: 20),
+                SizedBox(width: 8),
+                Text('Photo de la cible', style: TextStyle(fontWeight: FontWeight.w600)),
+              ],
+            ),
+            const SizedBox(height: 12),
+            if (isBusy)
+              const Padding(
+                padding: EdgeInsets.symmetric(vertical: 12.0),
+                child: Center(
+                  child: SizedBox(
+                    width: 24,
+                    height: 24,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                ),
+              )
+            else if (_hasPhoto) ...[
+              Stack(
+                children: [
+                  ClipRRect(
+                    borderRadius: BorderRadius.circular(12),
+                    child: Image(
+                      image: _resolveImageProvider(),
+                      width: double.infinity,
+                      height: 180,
+                      fit: BoxFit.cover,
+                      errorBuilder: (context, error, stackTrace) => Container(
+                        width: double.infinity,
+                        height: 180,
+                        color: Colors.black12,
+                        alignment: Alignment.center,
+                        child: const Text('Photo introuvable', style: TextStyle(color: Colors.white70)),
+                      ),
+                    ),
+                  ),
+                  Positioned(
+                    top: 6,
+                    right: 6,
+                    child: IconButton.filled(
+                      icon: const Icon(Icons.close, size: 18),
+                      tooltip: 'Supprimer la photo',
+                      onPressed: onRemove,
+                    ),
+                  ),
+                ],
+              ),
+              const SizedBox(height: 12),
+            ] else
+              const Padding(
+                padding: EdgeInsets.only(bottom: 4.0),
+                child: Text(
+                  'Aucune photo pour le moment',
+                  style: TextStyle(color: Colors.white54, fontSize: 12),
+                ),
+              ),
+            const SizedBox(height: 8),
+            Row(
+              children: [
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed: isBusy ? null : onPickFromGallery,
+                    icon: const Icon(Icons.photo_library_outlined),
+                    label: const Text('Galerie'),
+                  ),
+                ),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: OutlinedButton.icon(
+                    onPressed: isBusy ? null : onPickFromCamera,
+                    icon: const Icon(Icons.camera_alt_outlined),
+                    label: Text(_hasPhoto ? 'Reprendre' : 'Appareil photo'),
+                  ),
+                ),
+              ],
             ),
           ],
         ),

--- a/linux/flutter/generated_plugin_registrant.cc
+++ b/linux/flutter/generated_plugin_registrant.cc
@@ -6,11 +6,15 @@
 
 #include "generated_plugin_registrant.h"
 
+#include <file_selector_linux/file_selector_plugin.h>
 #include <flutter_secure_storage_linux/flutter_secure_storage_linux_plugin.h>
 #include <gtk/gtk_plugin.h>
 #include <url_launcher_linux/url_launcher_plugin.h>
 
 void fl_register_plugins(FlPluginRegistry* registry) {
+  g_autoptr(FlPluginRegistrar) file_selector_linux_registrar =
+      fl_plugin_registry_get_registrar_for_plugin(registry, "FileSelectorPlugin");
+  file_selector_plugin_register_with_registrar(file_selector_linux_registrar);
   g_autoptr(FlPluginRegistrar) flutter_secure_storage_linux_registrar =
       fl_plugin_registry_get_registrar_for_plugin(registry, "FlutterSecureStorageLinuxPlugin");
   flutter_secure_storage_linux_plugin_register_with_registrar(flutter_secure_storage_linux_registrar);

--- a/linux/flutter/generated_plugins.cmake
+++ b/linux/flutter/generated_plugins.cmake
@@ -3,6 +3,7 @@
 #
 
 list(APPEND FLUTTER_PLUGIN_LIST
+  file_selector_linux
   flutter_secure_storage_linux
   gtk
   url_launcher_linux

--- a/macos/Flutter/GeneratedPluginRegistrant.swift
+++ b/macos/Flutter/GeneratedPluginRegistrant.swift
@@ -7,6 +7,7 @@ import Foundation
 
 import app_links
 import file_picker
+import file_selector_macos
 import flutter_secure_storage_macos
 import path_provider_foundation
 import share_plus
@@ -15,6 +16,7 @@ import url_launcher_macos
 func RegisterGeneratedPlugins(registry: FlutterPluginRegistry) {
   AppLinksMacosPlugin.register(with: registry.registrar(forPlugin: "AppLinksMacosPlugin"))
   FilePickerPlugin.register(with: registry.registrar(forPlugin: "FilePickerPlugin"))
+  FileSelectorPlugin.register(with: registry.registrar(forPlugin: "FileSelectorPlugin"))
   FlutterSecureStoragePlugin.register(with: registry.registrar(forPlugin: "FlutterSecureStoragePlugin"))
   PathProviderPlugin.register(with: registry.registrar(forPlugin: "PathProviderPlugin"))
   SharePlusMacosPlugin.register(with: registry.registrar(forPlugin: "SharePlusMacosPlugin"))

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -141,10 +141,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -265,6 +265,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "8.3.7"
+  file_selector_linux:
+    dependency: transitive
+    description:
+      name: file_selector_linux
+      sha256: "2567f398e06ac72dcf2e98a0c95df2a9edd03c2c2e0cacd4780f20cdf56263a0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4"
+  file_selector_macos:
+    dependency: transitive
+    description:
+      name: file_selector_macos
+      sha256: "5e0bbe9c312416f1787a68259ea1505b52f258c587f12920422671807c4d618a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.5"
+  file_selector_platform_interface:
+    dependency: transitive
+    description:
+      name: file_selector_platform_interface
+      sha256: "35e0bd61ebcdb91a3505813b055b09b79dfdc7d0aee9c09a7ba59ae4bb13dc85"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.7.0"
+  file_selector_windows:
+    dependency: transitive
+    description:
+      name: file_selector_windows
+      sha256: "62197474ae75893a62df75939c777763d39c2bc5f73ce5b88497208bc269abfd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.3+5"
   fixnum:
     dependency: transitive
     description:
@@ -464,6 +496,70 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.5.4"
+  image_picker:
+    dependency: "direct main"
+    description:
+      name: image_picker
+      sha256: d8402284df184bc05f4a2210c6c23983b0720f4cd87cbd05c5390a78af602667
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.3"
+  image_picker_android:
+    dependency: transitive
+    description:
+      name: image_picker_android
+      sha256: "6f3a1995eafb000333174fae92202622033b0ee7fd917a6cd3730295264df84a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.13+19"
+  image_picker_for_web:
+    dependency: transitive
+    description:
+      name: image_picker_for_web
+      sha256: "66257a3191ab360d23a55c8241c91a6e329d31e94efa7be9cf7a212e65850214"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.1"
+  image_picker_ios:
+    dependency: transitive
+    description:
+      name: image_picker_ios
+      sha256: b9c4a438a9ff4f60808c9cf0039b93a42bb6c2211ef6ebb647394b2b3fa84588
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.8.13+6"
+  image_picker_linux:
+    dependency: transitive
+    description:
+      name: image_picker_linux
+      sha256: "1f81c5f2046b9ab724f85523e4af65be1d47b038160a8c8deed909762c308ed4"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
+  image_picker_macos:
+    dependency: transitive
+    description:
+      name: image_picker_macos
+      sha256: "86f0f15a309de7e1a552c12df9ce5b59fe927e71385329355aec4776c6a8ec91"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2+1"
+  image_picker_platform_interface:
+    dependency: transitive
+    description:
+      name: image_picker_platform_interface
+      sha256: "567e056716333a1647c64bb6bd873cff7622233a5c3f694be28a583d4715690c"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.1"
+  image_picker_windows:
+    dependency: transitive
+    description:
+      name: image_picker_windows
+      sha256: d248c86554a72b5495a31c56f060cf73a41c7ff541689327b1a7dbccc33adfae
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.2"
   intl:
     dependency: "direct main"
     description:
@@ -548,26 +644,26 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.19"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   meta:
     dependency: transitive
     description:
       name: meta
-      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
+      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
       url: "https://pub.dev"
     source: hosted
-    version: "1.16.0"
+    version: "1.18.0"
   mime:
     dependency: transitive
     description:
@@ -825,10 +921,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.11"
   typed_data:
     dependency: transitive
     description:
@@ -998,5 +1094,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.9.0 <4.0.0"
-  flutter: ">=3.35.0"
+  dart: ">=3.12.0 <4.0.0"
+  flutter: ">=3.44.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,6 +22,7 @@ dependencies:
   flutter_markdown: ^0.7.7+1
   yaml: ^3.1.3
   file_picker: ^8.0.0
+  image_picker: ^1.1.2
   share_plus: ^7.2.0
   url_launcher: ^6.2.6
   provider: ^6.1.1

--- a/test/migrations/migration_4_add_photo_path_field_test.dart
+++ b/test/migrations/migration_4_add_photo_path_field_test.dart
@@ -1,0 +1,78 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tir_sportif/migrations/migration_4_add_photo_path_field.dart';
+
+void main() {
+  group('Migration4AddPhotoPathField', () {
+    late Directory tempDir;
+
+    setUp(() async {
+      tempDir = await Directory.systemTemp.createTemp('nt_migration4_');
+      Hive.init(tempDir.path);
+    });
+
+    tearDown(() async {
+      if (Hive.isBoxOpen('sessions')) await Hive.box('sessions').close();
+      if (await tempDir.exists()) await tempDir.delete(recursive: true);
+    });
+
+    test('toVersion is 4', () {
+      expect(Migration4AddPhotoPathField().toVersion, 4);
+    });
+
+    test('is a no-op when the sessions box is not open', () async {
+      // La box n'est volontairement pas ouverte ici.
+      await Migration4AddPhotoPathField().apply();
+      expect(Hive.isBoxOpen('sessions'), isFalse);
+    });
+
+    test('ajoute photoPath=null aux sessions existantes qui ne l\'ont pas', () async {
+      final box = await Hive.openBox('sessions');
+      await box.put(1, {
+        'session': {'id': 1, 'weapon': 'P', 'caliber': '22LR'},
+        'series': [],
+      });
+
+      await Migration4AddPhotoPathField().apply();
+
+      final stored = Map<String, dynamic>.from(box.get(1));
+      final session = Map<String, dynamic>.from(stored['session']);
+      expect(session.containsKey('photoPath'), isTrue);
+      expect(session['photoPath'], isNull);
+    });
+
+    test('conserve un photoPath déjà présent', () async {
+      final box = await Hive.openBox('sessions');
+      await box.put(1, {
+        'session': {'id': 1, 'weapon': 'P', 'caliber': '22LR', 'photoPath': '/docs/session_photos/target_x.jpg'},
+        'series': [],
+      });
+
+      await Migration4AddPhotoPathField().apply();
+
+      final stored = Map<String, dynamic>.from(box.get(1));
+      final session = Map<String, dynamic>.from(stored['session']);
+      expect(session['photoPath'], '/docs/session_photos/target_x.jpg');
+    });
+
+    test('traite plusieurs sessions dans la box', () async {
+      final box = await Hive.openBox('sessions');
+      await box.put(1, {
+        'session': {'id': 1, 'weapon': 'P', 'caliber': '22LR'},
+        'series': [],
+      });
+      await box.put(2, {
+        'session': {'id': 2, 'weapon': 'C', 'caliber': '9mm', 'photoPath': '/docs/session_photos/target_y.jpg'},
+        'series': [],
+      });
+
+      await Migration4AddPhotoPathField().apply();
+
+      final s1 = Map<String, dynamic>.from(Map<String, dynamic>.from(box.get(1))['session']);
+      final s2 = Map<String, dynamic>.from(Map<String, dynamic>.from(box.get(2))['session']);
+      expect(s1['photoPath'], isNull);
+      expect(s2['photoPath'], '/docs/session_photos/target_y.jpg');
+    });
+  });
+}

--- a/test/models/shooting_session_model_test.dart
+++ b/test/models/shooting_session_model_test.dart
@@ -16,6 +16,7 @@ void main() {
         category: 'match',
         series: [Series(distance: 10, points: 50, groupSize: 20)],
         exercises: ['ex1'],
+        photoPath: '/tmp/session_photos/target_abc.jpg',
       );
       final map = ss.toMap();
       final ss2 = ShootingSession.fromMap(Map<String, dynamic>.from(map));
@@ -29,6 +30,8 @@ void main() {
       expect(ss2.exercises, ['ex1']);
       expect(ss2.hasAnalysis, isTrue);
       expect(ss2.hasSynthese, isTrue);
+      expect(ss2.photoPath, '/tmp/session_photos/target_abc.jpg');
+      expect(ss2.hasPhoto, isTrue);
     });
 
     test('fromMap tolerates missing/empty series and exercises', () {
@@ -41,6 +44,15 @@ void main() {
       expect(ss.category, 'entraînement');
       expect(ss.hasAnalysis, isFalse);
       expect(ss.hasSynthese, isFalse);
+      expect(ss.photoPath, isNull);
+      expect(ss.hasPhoto, isFalse);
+    });
+
+    test('hasPhoto is false for a blank photoPath', () {
+      final ss = ShootingSession(
+        weapon: 'P', caliber: '22LR', series: const [], photoPath: '   ',
+      );
+      expect(ss.hasPhoto, isFalse);
     });
   });
 }

--- a/test/screens/session_detail_screen_test.dart
+++ b/test/screens/session_detail_screen_test.dart
@@ -1,8 +1,78 @@
+import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tir_sportif/config/app_config.dart';
+import 'package:tir_sportif/constants/session_constants.dart';
+import 'package:tir_sportif/models/shooting_session.dart';
+import 'package:tir_sportif/screens/session_detail_screen.dart';
 
 void main() {
   TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SessionDetailScreen - photo de la cible (NT-005)', () {
+    setUpAll(() async {
+      await AppConfig.load();
+      final tempDir = await Directory.systemTemp.createTemp('nt_session_detail_test_');
+      Hive.init(tempDir.path);
+    });
+
+    // SessionDetailScreen est un long ListView ; on agrandit la surface de
+    // rendu pour que tout le contenu (dont SessionPhotoSection) soit
+    // effectivement construit par la Sliver, cf. le même besoin déjà
+    // rencontré dans test/widgets/session_form_test.dart.
+    Future<void> growSurface(WidgetTester tester) async {
+      await tester.binding.setSurfaceSize(const Size(800, 4000));
+      addTearDown(() => tester.binding.setSurfaceSize(null));
+    }
+
+    Map<String, dynamic> sessionData({String? photoPath}) {
+      final session = ShootingSession(
+        weapon: 'Pistolet test',
+        caliber: '22LR',
+        status: SessionConstants.statusPrevue,
+        series: const [],
+        photoPath: photoPath,
+      );
+      return {'session': session.toMap(), 'series': <dynamic>[]};
+    }
+
+    testWidgets(
+      'session avec photo : affiche SessionPhotoSection',
+      (tester) async {
+        await growSurface(tester);
+        await tester.pumpWidget(
+          MaterialApp(
+            home: SessionDetailScreen(
+              sessionData: sessionData(photoPath: '/nonexistent/photos/detail.jpg'),
+            ),
+          ),
+        );
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.text('Photo de la cible'), findsOneWidget);
+      },
+      timeout: const Timeout(Duration(minutes: 1)),
+    );
+
+    testWidgets(
+      'session sans photo : n\'affiche pas SessionPhotoSection',
+      (tester) async {
+        await growSurface(tester);
+        await tester.pumpWidget(
+          MaterialApp(
+            home: SessionDetailScreen(sessionData: sessionData()),
+          ),
+        );
+        await tester.pump();
+        await tester.pump();
+
+        expect(find.text('Photo de la cible'), findsNothing);
+      },
+      timeout: const Timeout(Duration(minutes: 1)),
+    );
+  });
 
   group('SessionDetailScreen UI Elements', () {
     testWidgets('affiche un titre approprié', (WidgetTester tester) async {

--- a/test/screens/session_photo_section_test.dart
+++ b/test/screens/session_photo_section_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:tir_sportif/screens/session_detail/session_detail_components.dart';
+
+// IMPORTANT : ces tests n'utilisent jamais Image.file/FileImage avec de
+// vrais octets de fichier. Le décodage réel d'image (dart:ui#
+// instantiateImageCodec) ne se résout jamais dans cet environnement de test
+// headless et bloque le test indéfiniment (vérifié expérimentalement :
+// TimeoutException after 0:10:00 même en attendant explicitement la
+// résolution du FileImage via tester.runAsync). On utilise donc
+// SessionPhotoSection.imageProviderBuilder pour injecter un ImageProvider de
+// test qui se résout immédiatement (en erreur) sans jamais passer par le
+// décodeur natif. Le rendu pixel de l'image n'est de toute façon pas ce que
+// ces tests vérifient : ils vérifient que le widget Image est bien présent
+// dans l'arbre et que les éléments construits de façon synchrone (titre)
+// s'affichent.
+class _FakeImageProvider extends ImageProvider<_FakeImageProvider> {
+  const _FakeImageProvider();
+
+  @override
+  Future<_FakeImageProvider> obtainKey(ImageConfiguration configuration) =>
+      SynchronousFuture<_FakeImageProvider>(this);
+
+  @override
+  ImageStreamCompleter loadImage(_FakeImageProvider key, ImageDecoderCallback decode) {
+    // Complète immédiatement en erreur (silencieuse côté flutter_test) : pas
+    // de décodage natif déclenché, le widget Image affiche son errorBuilder.
+    return OneFrameImageStreamCompleter(
+      Future<ImageInfo>.error(
+        StateError('_FakeImageProvider : pas de décodage réel en test'),
+      ),
+    );
+  }
+}
+
+void main() {
+  group('SessionPhotoSection', () {
+    testWidgets(
+      'affiche le titre et l\'image de la cible',
+      (tester) async {
+        const photoPath = '/fake/target_detail.jpg';
+        String? capturedPath;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SessionPhotoSection(
+                photoPath: photoPath,
+                imageProviderBuilder: (path) {
+                  capturedPath = path;
+                  return const _FakeImageProvider();
+                },
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(capturedPath, photoPath);
+        expect(find.text('Photo de la cible'), findsOneWidget);
+        expect(find.byType(Image), findsOneWidget);
+      },
+      timeout: const Timeout(Duration(minutes: 1)),
+    );
+
+    testWidgets(
+      'ne lève pas d\'exception si le fichier photo est introuvable',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SessionPhotoSection(photoPath: '/chemin/inexistant/photo.jpg'),
+            ),
+          ),
+        );
+
+        expect(tester.takeException(), isNull);
+        expect(find.text('Photo de la cible'), findsOneWidget);
+        expect(find.byType(Image), findsOneWidget);
+      },
+      timeout: const Timeout(Duration(minutes: 1)),
+    );
+
+    testWidgets(
+      'ouvre une vue plein écran au tap',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SessionPhotoSection(photoPath: '/chemin/inexistant/photo.jpg'),
+            ),
+          ),
+        );
+
+        await tester.tap(find.byType(GestureDetector));
+        await tester.pump();
+
+        expect(find.byType(Dialog), findsOneWidget);
+        expect(find.byType(InteractiveViewer), findsOneWidget);
+      },
+      timeout: const Timeout(Duration(minutes: 1)),
+    );
+  });
+}

--- a/test/screens/sessions_history_screen_test.dart
+++ b/test/screens/sessions_history_screen_test.dart
@@ -1,0 +1,228 @@
+import 'dart:io';
+import 'dart:typed_data';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:tir_sportif/constants/session_constants.dart';
+import 'package:tir_sportif/models/series.dart';
+import 'package:tir_sportif/models/shooting_session.dart';
+import 'package:tir_sportif/screens/sessions_history_screen.dart';
+import 'package:tir_sportif/services/exercise_service.dart';
+import 'package:tir_sportif/services/session_service.dart';
+
+/// Tests NT-007 : filtre par exercice dans l'historique des sessions,
+/// combinable avec le filtre réalisées/prévues déjà en place.
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late SessionService sessionService;
+  late ExerciseService exerciseService;
+
+  setUpAll(() async {
+    // Boxes 100 % en mémoire (bytes:) : aucune écriture disque, donc aucun
+    // deadlock entre la zone fake-async de testWidgets et la file d'écriture
+    // Hive (cf. le même besoin déjà rencontré dans
+    // test/screens/onboarding_screen_test.dart, NT-075) : un box adossé à un
+    // vrai fichier ne complète jamais ses I/O tant qu'on est dans la zone
+    // fake-async d'un testWidgets, ce qui bloque indéfiniment tout appel
+    // Hive fait directement dans le corps du test ou depuis initState().
+    final dir = await Directory.systemTemp.createTemp('nt_history_exercise_filter_test_');
+    Hive.init(dir.path);
+    await Hive.openBox('sessions', bytes: Uint8List(0));
+    await Hive.openBox('exercises', bytes: Uint8List(0));
+  });
+
+  setUp(() {
+    sessionService = SessionService();
+    exerciseService = ExerciseService();
+  });
+
+  tearDown(() async {
+    if (Hive.isBoxOpen('sessions')) await Hive.box('sessions').clear();
+    if (Hive.isBoxOpen('exercises')) await Hive.box('exercises').clear();
+  });
+
+  // L'écran est un long ListView ; on agrandit la surface de rendu pour que
+  // tout le contenu (dropdown + cartes) soit effectivement construit,
+  // cf. le même besoin dans test/screens/session_detail_screen_test.dart.
+  Future<void> growSurface(WidgetTester tester) async {
+    await tester.binding.setSurfaceSize(const Size(800, 4000));
+    addTearDown(() => tester.binding.setSurfaceSize(null));
+  }
+
+  Future<void> pumpScreen(WidgetTester tester) async {
+    await growSurface(tester);
+    await tester.pumpWidget(
+      MaterialApp(
+        home: Scaffold(body: SessionsHistoryScreen()),
+      ),
+    );
+    // Deux pumps : un pour le FutureBuilder en attente, un pour les données résolues.
+    await tester.pump();
+    await tester.pump();
+  }
+
+  group('SessionsHistoryScreen - filtre par exercice (NT-007)', () {
+    testWidgets('le sélecteur "Tous les exercices" affiche toutes les sessions réalisées', (tester) async {
+      await exerciseService.addExerciseLegacy(name: 'Précision debout', category: 'précision');
+      await exerciseService.addExerciseLegacy(name: 'Vitesse', category: 'vitesse');
+      final ex = await exerciseService.listAll();
+      final exA = ex.firstWhere((e) => e.name == 'Précision debout').id;
+      final exB = ex.firstWhere((e) => e.name == 'Vitesse').id;
+
+      await sessionService.addSession(ShootingSession(
+        weapon: 'P', caliber: '22LR', date: DateTime(2025, 1, 1),
+        status: SessionConstants.statusRealisee,
+        series: [Series(distance: 10, points: 90, groupSize: 20)],
+        exercises: [exA],
+      ));
+      await sessionService.addSession(ShootingSession(
+        weapon: 'P', caliber: '22LR', date: DateTime(2025, 1, 2),
+        status: SessionConstants.statusRealisee,
+        series: [Series(distance: 10, points: 80, groupSize: 25)],
+        exercises: [exB],
+      ));
+
+      await pumpScreen(tester);
+
+      expect(find.text('Filtrer par exercice'), findsOneWidget);
+      // Les deux sessions apparaissent (regroupées par jour car dates différentes).
+      expect(find.text('1/1/2025'), findsOneWidget);
+      expect(find.text('2/1/2025'), findsOneWidget);
+    });
+
+    testWidgets('sélectionner un exercice réduit la liste aux sessions liées', (tester) async {
+      await exerciseService.addExerciseLegacy(name: 'Précision debout', category: 'précision');
+      await exerciseService.addExerciseLegacy(name: 'Vitesse', category: 'vitesse');
+      final ex = await exerciseService.listAll();
+      final exA = ex.firstWhere((e) => e.name == 'Précision debout').id;
+      final exB = ex.firstWhere((e) => e.name == 'Vitesse').id;
+
+      await sessionService.addSession(ShootingSession(
+        weapon: 'P', caliber: '22LR', date: DateTime(2025, 1, 1),
+        status: SessionConstants.statusRealisee,
+        series: [Series(distance: 10, points: 90, groupSize: 20)],
+        exercises: [exA],
+      ));
+      await sessionService.addSession(ShootingSession(
+        weapon: 'P', caliber: '22LR', date: DateTime(2025, 1, 2),
+        status: SessionConstants.statusRealisee,
+        series: [Series(distance: 10, points: 80, groupSize: 25)],
+        exercises: [exB],
+      ));
+
+      await pumpScreen(tester);
+
+      // Ouvre le dropdown et sélectionne "Vitesse".
+      await tester.tap(find.text('Tous les exercices'));
+      await tester.pumpAndSettle();
+      // Deux occurrences possibles (item de menu + éventuel champ) : on prend la dernière (le menu ouvert).
+      await tester.tap(find.text('Vitesse').last);
+      await tester.pumpAndSettle();
+
+      expect(find.text('2/1/2025'), findsOneWidget);
+      expect(find.text('1/1/2025'), findsNothing);
+    });
+
+    testWidgets('le filtre exercice se combine avec le filtre réalisées/prévues', (tester) async {
+      await exerciseService.addExerciseLegacy(name: 'Précision debout', category: 'précision');
+      final ex = await exerciseService.listAll();
+      final exA = ex.first.id;
+
+      // Réalisée avec l'exercice -> doit apparaître en onglet "Réalisées" + filtre exercice.
+      await sessionService.addSession(ShootingSession(
+        weapon: 'P', caliber: '22LR', date: DateTime(2025, 1, 1),
+        status: SessionConstants.statusRealisee,
+        series: [Series(distance: 10, points: 90, groupSize: 20)],
+        exercises: [exA],
+      ));
+      // Prévue avec le même exercice -> ne doit PAS apparaître en onglet "Réalisées" + filtre exercice.
+      await sessionService.addSession(ShootingSession(
+        weapon: 'P', caliber: '22LR', date: null,
+        status: SessionConstants.statusPrevue,
+        series: [Series(distance: 10, points: 0, groupSize: 0)],
+        exercises: [exA],
+      ));
+
+      await pumpScreen(tester);
+
+      await tester.tap(find.text('Tous les exercices'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Précision debout').last);
+      await tester.pumpAndSettle();
+
+      // Réalisées + exercice : la session réalisée apparaît, la prévue non-groupée n'est pas listée
+      // comme réalisée. Elle peut apparaître dans la sous-section "Sessions prévues" du même onglet,
+      // donc on vérifie via le compteur du résumé plutôt que via l'absence totale du texte.
+      expect(find.text('1/1/2025'), findsOneWidget);
+
+      // Bascule sur l'onglet "Prévues" : avec le même filtre exercice actif, la session
+      // prévue doit apparaître, la réalisée ne doit plus être comptée.
+      await tester.tap(find.text('Prévues'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Filtrer par exercice'), findsOneWidget);
+    });
+
+    testWidgets('sélectionner un exercice sans session correspondante affiche un état vide dédié', (tester) async {
+      await exerciseService.addExerciseLegacy(name: 'Précision debout', category: 'précision');
+      await exerciseService.addExerciseLegacy(name: 'Vitesse', category: 'vitesse');
+      final ex = await exerciseService.listAll();
+      final exA = ex.firstWhere((e) => e.name == 'Précision debout').id;
+
+      await sessionService.addSession(ShootingSession(
+        weapon: 'P', caliber: '22LR', date: DateTime(2025, 1, 1),
+        status: SessionConstants.statusRealisee,
+        series: [Series(distance: 10, points: 90, groupSize: 20)],
+        exercises: [exA],
+      ));
+
+      await pumpScreen(tester);
+
+      await tester.tap(find.text('Tous les exercices'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Vitesse').last);
+      await tester.pumpAndSettle();
+
+      expect(find.text('Aucune session réalisée pour cet exercice'), findsOneWidget);
+      expect(find.text('Essaie un autre exercice ou réinitialise le filtre.'), findsOneWidget);
+    });
+
+    testWidgets('revenir à "Tous les exercices" réaffiche toutes les sessions', (tester) async {
+      await exerciseService.addExerciseLegacy(name: 'Précision debout', category: 'précision');
+      await exerciseService.addExerciseLegacy(name: 'Vitesse', category: 'vitesse');
+      final ex = await exerciseService.listAll();
+      final exA = ex.firstWhere((e) => e.name == 'Précision debout').id;
+      final exB = ex.firstWhere((e) => e.name == 'Vitesse').id;
+
+      await sessionService.addSession(ShootingSession(
+        weapon: 'P', caliber: '22LR', date: DateTime(2025, 1, 1),
+        status: SessionConstants.statusRealisee,
+        series: [Series(distance: 10, points: 90, groupSize: 20)],
+        exercises: [exA],
+      ));
+      await sessionService.addSession(ShootingSession(
+        weapon: 'P', caliber: '22LR', date: DateTime(2025, 1, 2),
+        status: SessionConstants.statusRealisee,
+        series: [Series(distance: 10, points: 80, groupSize: 25)],
+        exercises: [exB],
+      ));
+
+      await pumpScreen(tester);
+
+      await tester.tap(find.text('Tous les exercices'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Précision debout').last);
+      await tester.pumpAndSettle();
+      expect(find.text('2/1/2025'), findsNothing);
+
+      await tester.tap(find.text('Précision debout'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Tous les exercices').last);
+      await tester.pumpAndSettle();
+
+      expect(find.text('1/1/2025'), findsOneWidget);
+      expect(find.text('2/1/2025'), findsOneWidget);
+    });
+  });
+}

--- a/test/services/session_photo_service_test.dart
+++ b/test/services/session_photo_service_test.dart
@@ -1,0 +1,161 @@
+import 'dart:io';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:tir_sportif/services/session_photo_service.dart';
+
+/// [ImagePicker] fake : contourne le plugin natif (aucun handler de
+/// plateforme en environnement de test headless) en renvoyant directement un
+/// [XFile] pointant vers un fichier temporaire préparé par le test, pour
+/// exercer le chemin de succès complet de [SessionPhotoService.pickAndStore].
+class _FakeImagePicker extends ImagePicker {
+  _FakeImagePicker(this._pathToReturn);
+
+  final String? _pathToReturn;
+
+  @override
+  Future<XFile?> pickImage({
+    required ImageSource source,
+    double? maxWidth,
+    double? maxHeight,
+    int? imageQuality,
+    CameraDevice preferredCameraDevice = CameraDevice.rear,
+    bool requestFullMetadata = true,
+  }) async {
+    final path = _pathToReturn;
+    if (path == null) return null;
+    return XFile(path);
+  }
+}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  group('SessionPhotoService', () {
+    late SessionPhotoService service;
+
+    setUp(() {
+      service = SessionPhotoService();
+    });
+
+    test('deleteIfExists supprime un fichier existant', () async {
+      final tempDir = await Directory.systemTemp.createTemp('nt_photo_service_');
+      final file = File('${tempDir.path}/target_test.jpg');
+      await file.writeAsBytes([1, 2, 3]);
+      expect(await file.exists(), isTrue);
+
+      await service.deleteIfExists(file.path);
+
+      expect(await file.exists(), isFalse);
+      await tempDir.delete(recursive: true);
+    });
+
+    test('deleteIfExists ne lève pas d\'exception si le fichier est absent', () async {
+      final tempDir = await Directory.systemTemp.createTemp('nt_photo_service_');
+      final missing = '${tempDir.path}/does_not_exist.jpg';
+
+      await expectLater(service.deleteIfExists(missing), completes);
+
+      await tempDir.delete(recursive: true);
+    });
+
+    test('deleteIfExists est un no-op pour un chemin null ou vide', () async {
+      await expectLater(service.deleteIfExists(null), completes);
+      await expectLater(service.deleteIfExists(''), completes);
+      await expectLater(service.deleteIfExists('   '), completes);
+    });
+
+    test('pickAndStore retourne null au lieu de lever si le plugin natif est indisponible', () async {
+      // En environnement de test, aucun handler de plateforme n'est enregistré pour
+      // image_picker : l'appel doit être intercepté et renvoyer null plutôt que de
+      // propager une exception (cf. gestion d'erreur dans pickAndStore).
+      final result = await service.pickAndStore(ImageSource.gallery);
+      expect(result, isNull);
+    });
+
+    group('pickAndStore - chemin de succès (mock path_provider)', () {
+      // `getApplicationDocumentsDirectory` (path_provider) passe par un
+      // platform channel qui n'a aucun handler natif enregistré en
+      // environnement de test headless. On mocke ce channel pour renvoyer un
+      // répertoire temporaire réel, ce qui permet d'exercer _storeFile
+      // (copie effective du fichier sur disque) sans dépendance de
+      // plateforme. Technique standard Flutter :
+      // TestDefaultBinaryMessengerBinding.setMockMethodCallHandler.
+      const pathProviderChannel = MethodChannel('plugins.flutter.io/path_provider');
+      late Directory fakeDocsDir;
+      late Directory sourceDir;
+
+      setUp(() async {
+        fakeDocsDir = await Directory.systemTemp.createTemp('nt_fake_docs_');
+        sourceDir = await Directory.systemTemp.createTemp('nt_photo_source_');
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(pathProviderChannel, (MethodCall call) async {
+          if (call.method == 'getApplicationDocumentsDirectory') {
+            return fakeDocsDir.path;
+          }
+          return null;
+        });
+      });
+
+      tearDown(() async {
+        TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+            .setMockMethodCallHandler(pathProviderChannel, null);
+        if (await fakeDocsDir.exists()) await fakeDocsDir.delete(recursive: true);
+        if (await sourceDir.exists()) await sourceDir.delete(recursive: true);
+      });
+
+      test('copie le fichier sélectionné dans <docs>/session_photos/ et retourne son chemin', () async {
+        final sourceFile = File('${sourceDir.path}/original.png');
+        await sourceFile.writeAsBytes([1, 2, 3, 4]);
+
+        final fakePicker = _FakeImagePicker(sourceFile.path);
+        final service = SessionPhotoService(picker: fakePicker);
+
+        final result = await service.pickAndStore(ImageSource.gallery);
+
+        expect(result, isNotNull);
+        expect(result, startsWith('${fakeDocsDir.path}/session_photos/'));
+        expect(result, endsWith('.png'));
+        final storedFile = File(result!);
+        expect(await storedFile.exists(), isTrue);
+        expect(await storedFile.readAsBytes(), [1, 2, 3, 4]);
+      });
+
+      test('génère un nom de fichier unique à chaque appel', () async {
+        final sourceFile = File('${sourceDir.path}/shot.jpg');
+        await sourceFile.writeAsBytes([9, 9, 9]);
+
+        final service = SessionPhotoService(picker: _FakeImagePicker(sourceFile.path));
+
+        final first = await service.pickAndStore(ImageSource.camera);
+        final second = await service.pickAndStore(ImageSource.camera);
+
+        expect(first, isNotNull);
+        expect(second, isNotNull);
+        expect(first, isNot(equals(second)));
+      });
+
+      test('préserve une extension absente en retombant sur .jpg', () async {
+        final sourceFile = File('${sourceDir.path}/no_extension');
+        await sourceFile.writeAsBytes([5, 5]);
+
+        final service = SessionPhotoService(picker: _FakeImagePicker(sourceFile.path));
+
+        final result = await service.pickAndStore(ImageSource.gallery);
+
+        expect(result, isNotNull);
+        expect(result, endsWith('.jpg'));
+      });
+
+      test('retourne null sans copier de fichier si la sélection est annulée', () async {
+        final service = SessionPhotoService(picker: _FakeImagePicker(null));
+
+        final result = await service.pickAndStore(ImageSource.gallery);
+
+        expect(result, isNull);
+        final targetDir = Directory('${fakeDocsDir.path}/session_photos');
+        expect(await targetDir.exists(), isFalse);
+      });
+    });
+  });
+}

--- a/test/services/session_service_photo_test.dart
+++ b/test/services/session_service_photo_test.dart
@@ -1,0 +1,154 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:tir_sportif/services/session_service.dart';
+import 'package:tir_sportif/models/shooting_session.dart';
+import 'package:tir_sportif/repositories/session_repository.dart';
+import 'package:tir_sportif/interfaces/session_photo_service_interface.dart';
+import 'package:tir_sportif/constants/session_constants.dart';
+
+/// Fake in-memory du repository de sessions (pas de dépendance Hive).
+///
+/// Stocke des instantanés (via toMap/fromMap, comme le fait réellement
+/// [HiveSessionRepository] en sérialisant vers Hive) plutôt que la référence
+/// de l'objet [ShootingSession] : une mutation ultérieure de l'objet appelant
+/// ne doit pas modifier silencieusement la valeur déjà persistée.
+class _FakeSessionRepository implements SessionRepository {
+  final List<ShootingSession> sessions = [];
+  int _nextId = 1;
+
+  ShootingSession _snapshot(ShootingSession session) => ShootingSession.fromMap(session.toMap());
+
+  @override
+  Future<List<ShootingSession>> getAll() async => sessions.map(_snapshot).toList();
+
+  @override
+  Future<int> insert(ShootingSession session) async {
+    final id = _nextId++;
+    session.id = id;
+    sessions.add(_snapshot(session));
+    return id;
+  }
+
+  @override
+  Future<bool> update(ShootingSession session, {bool preserveExistingSeriesIfEmpty = true}) async {
+    final idx = sessions.indexWhere((s) => s.id == session.id);
+    if (idx >= 0) sessions[idx] = _snapshot(session);
+    return false;
+  }
+
+  @override
+  Future<void> delete(int id) async {
+    sessions.removeWhere((s) => s.id == id);
+  }
+
+  @override
+  Future<void> clearAll() async {
+    sessions.clear();
+  }
+}
+
+/// Fake du service de photo : ne fait qu'enregistrer les chemins supprimés,
+/// sans jamais toucher au disque ni au plugin image_picker.
+class _FakeSessionPhotoService implements ISessionPhotoService {
+  final List<String?> deletedPaths = [];
+
+  @override
+  Future<void> deleteIfExists(String? path) async {
+    deletedPaths.add(path);
+  }
+
+  @override
+  Future<String?> pickAndStore(ImageSource source) async => null;
+}
+
+void main() {
+  group('SessionService - nettoyage des photos (NT-005)', () {
+    late _FakeSessionRepository repo;
+    late _FakeSessionPhotoService photoService;
+    late SessionService service;
+
+    setUp(() {
+      repo = _FakeSessionRepository();
+      photoService = _FakeSessionPhotoService();
+      service = SessionService(repository: repo, photoService: photoService);
+    });
+
+    test('updateSession supprime l\'ancienne photo si elle est remplacée', () async {
+      final session = ShootingSession(
+        weapon: 'P', caliber: '22LR', status: SessionConstants.statusRealisee,
+        series: const [], photoPath: '/docs/old.jpg',
+      );
+      await service.addSession(session);
+
+      session.photoPath = '/docs/new.jpg';
+      await service.updateSession(session);
+
+      expect(photoService.deletedPaths, contains('/docs/old.jpg'));
+      expect(photoService.deletedPaths, isNot(contains('/docs/new.jpg')));
+    });
+
+    test('updateSession ne supprime rien si la photo est inchangée', () async {
+      final session = ShootingSession(
+        weapon: 'P', caliber: '22LR', status: SessionConstants.statusRealisee,
+        series: const [], photoPath: '/docs/same.jpg',
+      );
+      await service.addSession(session);
+
+      await service.updateSession(session);
+
+      expect(photoService.deletedPaths, isEmpty);
+    });
+
+    test('updateSession supprime l\'ancienne photo si elle est retirée', () async {
+      final session = ShootingSession(
+        weapon: 'P', caliber: '22LR', status: SessionConstants.statusRealisee,
+        series: const [], photoPath: '/docs/old.jpg',
+      );
+      await service.addSession(session);
+
+      session.photoPath = null;
+      await service.updateSession(session);
+
+      expect(photoService.deletedPaths, contains('/docs/old.jpg'));
+    });
+
+    test('deleteSession supprime la photo associée', () async {
+      final session = ShootingSession(
+        weapon: 'P', caliber: '22LR', status: SessionConstants.statusRealisee,
+        series: const [], photoPath: '/docs/to_delete.jpg',
+      );
+      await service.addSession(session);
+
+      await service.deleteSession(session.id!);
+
+      expect(photoService.deletedPaths, contains('/docs/to_delete.jpg'));
+    });
+
+    test('deleteSession ne tente pas de supprimer si aucune photo n\'est associée', () async {
+      final session = ShootingSession(
+        weapon: 'P', caliber: '22LR', status: SessionConstants.statusRealisee,
+        series: const [],
+      );
+      await service.addSession(session);
+
+      await service.deleteSession(session.id!);
+
+      expect(photoService.deletedPaths, isEmpty);
+    });
+
+    test('clearAllSessions supprime toutes les photos existantes avant la purge', () async {
+      final s1 = ShootingSession(weapon: 'P', caliber: '22LR', status: SessionConstants.statusRealisee, series: const [], photoPath: '/docs/a.jpg');
+      final s2 = ShootingSession(weapon: 'C', caliber: '9mm', status: SessionConstants.statusRealisee, series: const [], photoPath: '/docs/b.jpg');
+      final s3 = ShootingSession(weapon: 'R', caliber: '.38', status: SessionConstants.statusRealisee, series: const []);
+      await service.addSession(s1);
+      await service.addSession(s2);
+      await service.addSession(s3);
+
+      await service.clearAllSessions();
+
+      expect(photoService.deletedPaths, containsAll(['/docs/a.jpg', '/docs/b.jpg']));
+      final remaining = await repo.getAll();
+      expect(remaining, isEmpty);
+    });
+  });
+}

--- a/test/session_filters_test.dart
+++ b/test/session_filters_test.dart
@@ -34,4 +34,52 @@ void main() {
       expect(filtered.first.id, 1);
     });
   });
+
+  group('SessionFilters.byExercise', () {
+    ShootingSession makeSession({required int id, required List<String> exercises, String status = SessionConstants.statusRealisee}) {
+      return ShootingSession(
+        id: id,
+        date: DateTime(2025, 10, id),
+        weapon: 'P', caliber: '22LR',
+        status: status,
+        series: [Series(distance: 10, points: 90, groupSize: 20)],
+        exercises: exercises,
+      );
+    }
+
+    test('ne garde que les sessions liées à l\'exercice donné', () {
+      final s1 = makeSession(id: 1, exercises: ['ex-a']);
+      final s2 = makeSession(id: 2, exercises: ['ex-b']);
+      final s3 = makeSession(id: 3, exercises: ['ex-a', 'ex-b']);
+
+      final filtered = SessionFilters.byExercise([s1, s2, s3], 'ex-a');
+      expect(filtered.map((s) => s.id).toSet(), {1, 3});
+    });
+
+    test('exerciseId null ne filtre rien (retourne toutes les sessions)', () {
+      final s1 = makeSession(id: 1, exercises: ['ex-a']);
+      final s2 = makeSession(id: 2, exercises: []);
+
+      final filtered = SessionFilters.byExercise([s1, s2], null);
+      expect(filtered.length, 2);
+    });
+
+    test('exercice sans aucune session correspondante retourne une liste vide', () {
+      final s1 = makeSession(id: 1, exercises: ['ex-a']);
+
+      final filtered = SessionFilters.byExercise([s1], 'ex-inconnu');
+      expect(filtered, isEmpty);
+    });
+
+    test('est combinable avec un filtre de statut (réalisées + exercice)', () {
+      final realizedWithEx = makeSession(id: 1, exercises: ['ex-a']);
+      final plannedWithEx = makeSession(id: 2, exercises: ['ex-a'], status: SessionConstants.statusPrevue);
+      final realizedWithoutEx = makeSession(id: 3, exercises: ['ex-b']);
+
+      final byExercise = SessionFilters.byExercise([realizedWithEx, plannedWithEx, realizedWithoutEx], 'ex-a');
+      final byExerciseAndStatus = SessionFilters.realizedWithDate(byExercise);
+
+      expect(byExerciseAndStatus.map((s) => s.id).toList(), [1]);
+    });
+  });
 }

--- a/test/widgets/session_form_components_test.dart
+++ b/test/widgets/session_form_components_test.dart
@@ -1,7 +1,38 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/foundation.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:tir_sportif/widgets/session_form/session_form_components.dart';
 import 'package:tir_sportif/models/exercise.dart';
+
+// IMPORTANT : ne jamais faire passer un vrai fichier (octets valides ou non)
+// par Image.file/FileImage dans ces tests. Le décodage réel d'image
+// (dart:ui#instantiateImageCodec) ne se résout jamais dans cet environnement
+// de test headless et bloque le test indéfiniment (vérifié expérimentalement
+// : TimeoutException after 0:10:00 même en attendant explicitement la
+// résolution du FileImage via tester.runAsync). SessionPhotoField expose
+// imageProviderBuilder pour injecter un ImageProvider de test qui se résout
+// immédiatement (en erreur) sans jamais passer par le décodeur natif. Le
+// rendu pixel de l'image n'est de toute façon pas ce que ces tests
+// vérifient : ils vérifient uniquement les éléments construits de façon
+// synchrone autour de l'image (bouton supprimer, libellé "Reprendre", etc.).
+class _FakeImageProvider extends ImageProvider<_FakeImageProvider> {
+  const _FakeImageProvider();
+
+  @override
+  Future<_FakeImageProvider> obtainKey(ImageConfiguration configuration) =>
+      SynchronousFuture<_FakeImageProvider>(this);
+
+  @override
+  ImageStreamCompleter loadImage(_FakeImageProvider key, ImageDecoderCallback decode) {
+    // Complète immédiatement en erreur (silencieuse côté flutter_test) : pas
+    // de décodage natif déclenché, le widget Image affiche son errorBuilder.
+    return OneFrameImageStreamCompleter(
+      Future<ImageInfo>.error(
+        StateError('_FakeImageProvider : pas de décodage réel en test'),
+      ),
+    );
+  }
+}
 
 void main() {
   group('FormSummaryHeader', () {
@@ -271,5 +302,115 @@ void main() {
 
       expect(find.text('(1)'), findsOneWidget);
     });
+  });
+
+  group('SessionPhotoField', () {
+    testWidgets(
+      'sans photo : propose Galerie et Appareil photo',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SessionPhotoField(
+                photoPath: null,
+                onPickFromGallery: () {},
+                onPickFromCamera: () {},
+                onRemove: () {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.text('Galerie'), findsOneWidget);
+        expect(find.text('Appareil photo'), findsOneWidget);
+        expect(find.text('Aucune photo pour le moment'), findsOneWidget);
+        expect(find.byIcon(Icons.close), findsNothing);
+      },
+      timeout: const Timeout(Duration(minutes: 1)),
+    );
+
+    testWidgets(
+      'onPickFromGallery et onPickFromCamera sont appelés',
+      (tester) async {
+        bool galleryCalled = false;
+        bool cameraCalled = false;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SessionPhotoField(
+                photoPath: null,
+                onPickFromGallery: () => galleryCalled = true,
+                onPickFromCamera: () => cameraCalled = true,
+                onRemove: () {},
+              ),
+            ),
+          ),
+        );
+
+        await tester.tap(find.text('Galerie'));
+        await tester.tap(find.text('Appareil photo'));
+
+        expect(galleryCalled, isTrue);
+        expect(cameraCalled, isTrue);
+      },
+      timeout: const Timeout(Duration(minutes: 1)),
+    );
+
+    testWidgets(
+      'affiche un indicateur de chargement quand isBusy=true et désactive les boutons',
+      (tester) async {
+        bool galleryCalled = false;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SessionPhotoField(
+                photoPath: null,
+                isBusy: true,
+                onPickFromGallery: () => galleryCalled = true,
+                onPickFromCamera: () {},
+                onRemove: () {},
+              ),
+            ),
+          ),
+        );
+
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+        await tester.tap(find.text('Galerie'), warnIfMissed: false);
+        expect(galleryCalled, isFalse);
+      },
+      timeout: const Timeout(Duration(minutes: 1)),
+    );
+
+    testWidgets(
+      'avec une photo : affiche le bouton supprimer et "Reprendre"',
+      (tester) async {
+        const photoPath = '/fake/target_test.jpg';
+        bool removed = false;
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SessionPhotoField(
+                photoPath: photoPath,
+                imageProviderBuilder: (_) => const _FakeImageProvider(),
+                onPickFromGallery: () {},
+                onPickFromCamera: () {},
+                onRemove: () => removed = true,
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.byIcon(Icons.close), findsOneWidget);
+        expect(find.text('Reprendre'), findsOneWidget);
+
+        await tester.tap(find.byIcon(Icons.close));
+        expect(removed, isTrue);
+      },
+      timeout: const Timeout(Duration(minutes: 1)),
+    );
   });
 }

--- a/test/widgets/session_form_test.dart
+++ b/test/widgets/session_form_test.dart
@@ -1,0 +1,215 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:tir_sportif/config/app_config.dart';
+import 'package:tir_sportif/constants/session_constants.dart';
+import 'package:tir_sportif/interfaces/session_photo_service_interface.dart';
+import 'package:tir_sportif/models/shooting_session.dart';
+import 'package:tir_sportif/widgets/session_form.dart';
+
+// IMPORTANT : les chemins de photo utilisés dans ces tests pointent
+// délibérément vers des fichiers inexistants (jamais de vrais octets
+// d'image). SessionPhotoField (utilisé par SessionForm) ne propose pas de
+// point d'injection pour l'ImageProvider ; avec un chemin inexistant,
+// FileImage échoue tôt (File.readAsBytes lève avant tout appel au décodeur
+// dart:ui#instantiateImageCodec), donc aucun risque de blocage — cf. le même
+// choix déjà validé dans test/screens/session_photo_section_test.dart
+// (cas "fichier introuvable").
+class _FakeSessionPhotoService implements ISessionPhotoService {
+  /// Valeur renvoyée par le prochain appel à [pickAndStore] (null = annulation).
+  String? nextPickResult;
+  final List<ImageSource> pickCalls = [];
+  final List<String?> deletedPaths = [];
+
+  @override
+  Future<String?> pickAndStore(ImageSource source) async {
+    pickCalls.add(source);
+    return nextPickResult;
+  }
+
+  @override
+  Future<void> deleteIfExists(String? path) async {
+    deletedPaths.add(path);
+  }
+}
+
+/// SessionForm est un long ListView (résumé, champs, exercices, séries, photo,
+/// synthèse) qui dépasse largement la taille par défaut de la surface de test
+/// (800x600) : sans agrandir la surface, la Sliver ne construit même pas les
+/// éléments hors du viewport+cacheExtent (dont SessionPhotoField), et les
+/// finders les cherchant échouent silencieusement (0 widget trouvé). On
+/// agrandit donc la surface de rendu pour que tout le formulaire soit
+/// construit sans avoir besoin de scroller dans chaque test.
+Future<void> _growSurface(WidgetTester tester) async {
+  await tester.binding.setSurfaceSize(const Size(800, 4000));
+  addTearDown(() => tester.binding.setSurfaceSize(null));
+}
+
+Map<String, dynamic> _sessionData({String? photoPath}) => {
+      'session': {
+        'weapon': 'Pistolet 22',
+        'caliber': '.22 LR',
+        'status': SessionConstants.statusPrevue, // évite les contraintes date/séries pour simplifier le montage
+        'category': SessionConstants.categoryEntrainement,
+        'synthese': '',
+        'exercises': <String>[],
+        'photoPath': photoPath,
+      },
+      'series': <dynamic>[],
+    };
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  setUpAll(() async {
+    await AppConfig.load(); // échoue silencieusement (assets indisponibles en test) et installe la config par défaut
+    final tempDir = await Directory.systemTemp.createTemp('nt_session_form_test_');
+    Hive.init(tempDir.path);
+    if (!Hive.isBoxOpen('app_preferences')) {
+      await Hive.openBox('app_preferences');
+    }
+  });
+
+  group('SessionForm - photo de la cible (NT-005)', () {
+    testWidgets(
+      'sans photo initiale : tap Galerie déclenche pickAndStore et le nouveau photoPath est transmis à onSave',
+      (tester) async {
+        await _growSurface(tester);
+        final photoService = _FakeSessionPhotoService()
+          ..nextPickResult = '/nonexistent/photos/new_photo.jpg';
+        ShootingSession? saved;
+        final formKey = GlobalKey<SessionFormState>();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SessionForm(
+                key: formKey,
+                initialSessionData: _sessionData(),
+                photoService: photoService,
+                onSave: (s) => saved = s,
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        expect(find.text('Aucune photo pour le moment'), findsOneWidget);
+
+        await tester.tap(find.text('Galerie'));
+        await tester.pump(); // _photoBusy = true
+        await tester.pump(); // pickAndStore résolu, _photoPath mis à jour
+
+        expect(photoService.pickCalls, [ImageSource.gallery]);
+        expect(find.text('Reprendre'), findsOneWidget); // preuve que _photoPath n'est plus null
+        expect(find.byIcon(Icons.close), findsOneWidget);
+
+        final ok = formKey.currentState!.validateAndBuild();
+
+        expect(ok, isTrue);
+        expect(saved, isNotNull);
+        expect(saved!.photoPath, '/nonexistent/photos/new_photo.jpg');
+      },
+      timeout: const Timeout(Duration(minutes: 1)),
+    );
+
+    testWidgets(
+      'le bouton supprimer déclenche _removePhoto et remet photoPath à null',
+      (tester) async {
+        await _growSurface(tester);
+        final photoService = _FakeSessionPhotoService()
+          ..nextPickResult = '/nonexistent/photos/picked.jpg';
+        ShootingSession? saved;
+        final formKey = GlobalKey<SessionFormState>();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SessionForm(
+                key: formKey,
+                initialSessionData: _sessionData(),
+                photoService: photoService,
+                onSave: (s) => saved = s,
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        // Sélectionne d'abord une photo pour faire apparaître le bouton supprimer.
+        await tester.tap(find.text('Galerie'));
+        await tester.pump();
+        await tester.pump();
+        expect(find.byIcon(Icons.close), findsOneWidget);
+
+        await tester.tap(find.byIcon(Icons.close));
+        await tester.pump();
+
+        expect(find.text('Aucune photo pour le moment'), findsOneWidget);
+        expect(find.byIcon(Icons.close), findsNothing);
+        // La photo était temporaire (jamais persistée) : elle est bien nettoyée.
+        expect(photoService.deletedPaths, contains('/nonexistent/photos/picked.jpg'));
+
+        final ok = formKey.currentState!.validateAndBuild();
+        expect(ok, isTrue);
+        expect(saved!.photoPath, isNull);
+      },
+      timeout: const Timeout(Duration(minutes: 1)),
+    );
+
+    testWidgets(
+      'édition avec photo initiale : remplacer la photo supprime la précédente mais pas la photo initiale tant que non modifiée',
+      (tester) async {
+        await _growSurface(tester);
+        const initialPath = '/nonexistent/photos/initial.jpg';
+        final photoService = _FakeSessionPhotoService()
+          ..nextPickResult = '/nonexistent/photos/replacement.jpg';
+        ShootingSession? saved;
+        final formKey = GlobalKey<SessionFormState>();
+
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: SessionForm(
+                key: formKey,
+                initialSessionData: _sessionData(photoPath: initialPath),
+                isEdit: true,
+                photoService: photoService,
+                onSave: (s) => saved = s,
+              ),
+            ),
+          ),
+        );
+        await tester.pump();
+
+        // La photo initiale est déjà affichée (bouton Reprendre visible dès le montage).
+        expect(find.text('Reprendre'), findsOneWidget);
+
+        // Prendre une nouvelle photo (Appareil photo) remplace le chemin en mémoire ;
+        // comme oldPath (initialPath) == _initialPhotoPath, elle ne doit PAS être supprimée
+        // immédiatement (elle reste potentiellement affichée/persistée tant que non sauvegardée).
+        await tester.tap(find.text('Reprendre'));
+        await tester.pump();
+        await tester.pump();
+
+        expect(photoService.pickCalls, [ImageSource.camera]);
+        expect(photoService.deletedPaths, isNot(contains(initialPath)));
+
+        // Suppression manuelle ensuite : la photo courante (replacement, != _initialPhotoPath)
+        // doit être supprimée, l'initiale ne l'est toujours pas puisqu'elle n'était déjà plus active.
+        await tester.tap(find.byIcon(Icons.close));
+        await tester.pump();
+
+        expect(photoService.deletedPaths, contains('/nonexistent/photos/replacement.jpg'));
+        expect(photoService.deletedPaths, isNot(contains(initialPath)));
+
+        final ok = formKey.currentState!.validateAndBuild();
+        expect(ok, isTrue);
+        expect(saved!.photoPath, isNull);
+      },
+      timeout: const Timeout(Duration(minutes: 1)),
+    );
+  });
+}

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -7,6 +7,7 @@
 #include "generated_plugin_registrant.h"
 
 #include <app_links/app_links_plugin_c_api.h>
+#include <file_selector_windows/file_selector_windows.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <share_plus/share_plus_windows_plugin_c_api.h>
 #include <url_launcher_windows/url_launcher_windows.h>
@@ -14,6 +15,8 @@
 void RegisterPlugins(flutter::PluginRegistry* registry) {
   AppLinksPluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("AppLinksPluginCApi"));
+  FileSelectorWindowsRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   SharePlusWindowsPluginCApiRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -4,6 +4,7 @@
 
 list(APPEND FLUTTER_PLUGIN_LIST
   app_links
+  file_selector_windows
   flutter_secure_storage_windows
   share_plus
   url_launcher_windows


### PR DESCRIPTION
NT-005 : ajout d'une photo de la cible en fin de session (sélection galerie ou prise via appareil photo, stockage local persistant dans les documents de l'app, affichage dans le détail de session). Migration Hive v4 pour le nouveau champ `photoPath`.

NT-007 : filtre par exercice dans l'historique des sessions, combinable avec le filtre réalisées/prévues existant.

Tests : 265 tests passent (0 échec), flutter analyze propre. Couverture globale du projet : 52.68% (contre 41.21% sur main), +11.5pt grâce aux tests de ces deux tickets. Reste sous le seuil cible de 60% en raison d'une dette de tests préexistante sur du code non lié à ces tickets (voir description de la PR).

## Objet de la PR

- [x] Analyse SonarCloud OK
- [x] Tests unitaires verts
- [x] Couverture >= 50% (objectif)
- [x] Pas de secrets commités

## Description

Décrivez brièvement les changements, motivations, et impacts.

## Checklist

- [x] `flutter test --coverage` exécuté en local
- [x] `dart analyze` (optionnel) ne remonte pas d’erreurs
- [x] Mise à jour des docs si nécessaire (README, specs)
- [x] Cahier de recette mis à jour et recette manuelle validée
